### PR TITLE
Prepare for PyPI release as mnemosyne-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,11 +459,13 @@ Implementation: `hasher.py` — `content_hash`, `file_hash`; `bloom.py` — `Blo
 ### Installation
 
 ```bash
-# pip-installable (pyproject.toml included)
-pip install -e /path/to/mnemosyne
+# Install from PyPI
+pip install mnemosyne-engine
 
-# Or run directly as a module
-python -m mnemosyne --help
+# Or install from source (for development)
+git clone https://github.com/castnettech/mnemosyne.git
+cd mnemosyne
+pip install -e .
 ```
 
 ### Initialize a Project
@@ -1059,7 +1061,7 @@ Mnemosyne is built entirely on the **Python 3.11+ standard library**. No externa
 
 The zero-dependency design is a deliberate constraint, not an oversight. It means:
 
-- **Installation is one command** — `pip install -e .` with no conflict resolution.
+- **Installation is one command** — `pip install mnemosyne-engine` with no conflict resolution.
 - **Deployment is trivial** — copy the directory, run Python.
 - **Security surface is minimal** — no third-party supply chain to audit.
 - **Compatibility is guaranteed** — any Python 3.11+ environment works.
@@ -1181,7 +1183,7 @@ Full algorithm details, design rationale, and academic paper references are in *
 - **Compression Safety Net** -- Control flow lines preserved, 70% max prune ratio, strict mode for symbol chunks.
 - **Analytics CLI** -- `mnemosyne analytics` shows precision-at-k from feedback events and top-used chunks.
 - **Benchmark Suite** -- Multi-project runner with chunk-level precision measurement.
-- **pip-installable Packaging** -- `pyproject.toml` with `pip install -e .` support.
+- **PyPI Package** -- `pip install mnemosyne-engine` (import name remains `mnemosyne`).
 - **ALGORITHMS.md** -- Full algorithm documentation with paper references.
 
 ### Planned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,32 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mnemosyne"
+name = "mnemosyne-engine"
 version = "0.3.0"
-description = "LLM Context Compression and Retrieval Engine"
+description = "LLM Context Compression and Retrieval Engine — zero dependencies, sub-100ms queries, 40-70% token reduction"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "AGPL-3.0-or-later"
 authors = [{name = "Cast Rock Innovation L.L.C."}]
+keywords = ["llm", "context", "compression", "retrieval", "token", "mnemosyne", "code-search", "bm25", "tfidf"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Text Processing :: Indexing",
+    "Typing :: Typed",
+]
 
 [project.urls]
 Homepage = "https://castnettechnology.com"
 Repository = "https://github.com/castnettech/mnemosyne"
+Documentation = "https://github.com/castnettech/mnemosyne#readme"
+Issues = "https://github.com/castnettech/mnemosyne/issues"
 
 [project.scripts]
 mnemosyne = "mnemosyne.cli:main"


### PR DESCRIPTION
  - Distribution name: mnemosyne-engine (pip install mnemosyne-engine)
  - Import name unchanged: mnemosyne
  - CLI command unchanged: mnemosyne
  - Added PyPI classifiers, keywords, and project URLs
  - Updated README install instructions