### PR TITLE
Remove legacy license classifier — conflicts with SPDX expression (#3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ keywords = ["llm", "context", "compression", "retrieval", "token", "mnemosyne", 
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Housekeeping
- Remove legacy license classifier — conflicts with SPDX expression