### PR TITLE
Add optional runtime integration hooks in agent, CLI, and MCP server

### DIFF
--- a/mcp/src/mnemosyne_mcp/server.py
+++ b/mcp/src/mnemosyne_mcp/server.py
@@ -38,6 +38,40 @@ from mcp.types import TextContent, Tool
 
 _engine_cache: dict[str, object] = {}
 
+# ---------------------------------------------------------------------------
+# Optional runtime integration point.
+# ---------------------------------------------------------------------------
+
+_capture = None
+_mcp_conv_id: str | None = None
+
+
+async def _start_capture() -> None:
+    """Optional session state hook."""
+    global _capture, _mcp_conv_id
+    try:
+        from mnemosyne_capture.capture import Capture
+        _capture = Capture(Path.cwd())
+        await _capture.start()
+        _mcp_conv_id = _capture.new_conversation(source="mcp", model_id="unknown")
+    except ImportError:
+        _capture = None
+        _mcp_conv_id = None
+    except Exception:
+        _capture = None
+        _mcp_conv_id = None
+
+
+async def _stop_capture() -> None:
+    """Optional session state hook."""
+    global _capture
+    if _capture is not None:
+        try:
+            await _capture.stop()
+        except Exception:
+            pass
+        _capture = None
+
 
 def _get_engine(project_root: str) -> tuple:
     """Return (RetrievalEngine, Store, Config, DocRetrievalEngine, DocStore) for project root.
@@ -297,23 +331,51 @@ async def list_tools() -> list[Tool]:
 
 @server.call_tool()
 async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    import json as _json
+
+    # Turn record hook.
+    if _capture is not None and _mcp_conv_id:
+        try:
+            _capture.record(
+                _mcp_conv_id,
+                author="assistant",
+                content=f"[tool:{name}] {_json.dumps(arguments, separators=(',', ':'))}",
+                capture_source="mcp_middleware",
+            )
+        except Exception:
+            pass
+
+    result: list[TextContent] = []
     try:
         if name == "search":
-            return await _handle_search(arguments)
+            result = await _handle_search(arguments)
         elif name == "search_docs":
-            return await _handle_search_docs(arguments)
+            result = await _handle_search_docs(arguments)
         elif name == "index":
-            return await _handle_index(arguments)
+            result = await _handle_index(arguments)
         elif name == "stats":
-            return await _handle_stats(arguments)
+            result = await _handle_stats(arguments)
         elif name == "schema_ingest":
-            return await _handle_schema_ingest(arguments)
+            result = await _handle_schema_ingest(arguments)
         elif name == "schema_stats":
-            return await _handle_schema_stats(arguments)
+            result = await _handle_schema_stats(arguments)
         else:
-            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+            result = [TextContent(type="text", text=f"Unknown tool: {name}")]
     except Exception as exc:
-        return [TextContent(type="text", text=f"Error: {type(exc).__name__}: {exc}")]
+        result = [TextContent(type="text", text=f"Error: {type(exc).__name__}: {exc}")]
+    finally:
+        # Turn record hook.
+        if _capture is not None and _mcp_conv_id and result:
+            try:
+                _capture.record(
+                    _mcp_conv_id,
+                    author="tool",
+                    content=result[0].text,
+                    capture_source="mcp_middleware",
+                )
+            except Exception:
+                pass
+    return result
 
 
 async def _handle_search(arguments: dict) -> list[TextContent]:
@@ -638,12 +700,16 @@ def run():
 
 async def main() -> None:
     """Run the Mnemosyne MCP server over stdio."""
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            server.create_initialization_options(),
-        )
+    await _start_capture()
+    try:
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+    finally:
+        await _stop_capture()
 
 
 if __name__ == "__main__":

--- a/ollama/src/mnemosyne_ollama/agent.py
+++ b/ollama/src/mnemosyne_ollama/agent.py
@@ -89,7 +89,8 @@ Rules:
 - Cite file paths and line numbers from results.
 - Be concise. Quote relevant code, don't paraphrase.
 - Project root: {project_root}
-- Default search budget: {budget}"""
+- Default search budget: {budget}
+- Current session model: {model}"""
 
 
 @dataclass
@@ -202,10 +203,29 @@ async def run(
         if verbose:
             print(f"[mnemosyne-ollama] auto-detected model: {model}", file=sys.stderr)
 
+    # Optional runtime integration point.
+    _capture = None
+    _conv_id = None
+    try:
+        from mnemosyne_capture.capture import Capture
+        _capture = Capture(Path(root))
+        await _capture.start()
+        _conv_id = _capture.new_conversation(source="ollama_agent", model_id=model)
+    except ImportError:
+        pass
+    except Exception:
+        _capture = None
+
     bridge = McpBridge()
     try:
         await bridge.start()
     except FileNotFoundError:
+        # Session state hook.
+        if _capture is not None:
+            try:
+                await _capture.stop()
+            except Exception:
+                pass
         return AgentResult(
             response="",
             error="mnemosyne-mcp not found on PATH. Install: pip install mnemosyne-mcp",
@@ -215,10 +235,39 @@ async def run(
         tools = bridge.get_tools_for_ollama()
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT.format(
-                project_root=root, budget=budget
+                project_root=root, budget=budget, model=model
             )},
             {"role": "user", "content": query},
         ]
+
+        # Turn record hook.
+        if _capture is not None and _conv_id:
+            try:
+                _capture.record(
+                    _conv_id, author="user", content=query,
+                    capture_source="ollama_agent",
+                )
+            except Exception:
+                pass
+
+        # Optional context pre-load.
+        _ctx_cache = None
+        if _capture is not None and _conv_id:
+            try:
+                from mnemosyne_capture.auto_inject import ContextCache, BUDGET_ONE_SHOT
+                from mnemosyne_capture.engine import ConversationRetrievalEngine
+                _ctx_engine = ConversationRetrievalEngine(_capture.store, tfidf=None)
+                _ctx_cache = ContextCache(_ctx_engine)
+                _ctx_block = _ctx_cache.get_context_block(
+                    _conv_id, query, budget=BUDGET_ONE_SHOT
+                )
+                if _ctx_block:
+                    messages[0] = {
+                        **messages[0],
+                        "content": messages[0]["content"] + "\n\n" + _ctx_block,
+                    }
+            except Exception:
+                _ctx_cache = None
 
         loop = asyncio.get_running_loop()
         max_steps = 10
@@ -233,7 +282,40 @@ async def run(
             tool_calls = msg.get("tool_calls") or []
 
             if not tool_calls:
+                # Turn record hook.
+                if _capture is not None and _conv_id and content:
+                    try:
+                        _capture.record(
+                            _conv_id, author="assistant", content=content,
+                            capture_source="ollama_agent",
+                        )
+                    except Exception:
+                        pass
+                # Optional session finalization hook.
+                if _capture is not None and _conv_id:
+                    try:
+                        _capture.store.set_conversation_state(_conv_id, "closed")
+                        from mnemosyne_capture.summarizer_l3 import summarize_conversation
+                        summarize_conversation(_capture.store, _conv_id, model=model)
+                    except Exception:
+                        pass
+                # Optional prefetch hook.
+                if _ctx_cache is not None and _conv_id and content:
+                    try:
+                        _ctx_cache.prefetch(_conv_id, content)
+                    except Exception:
+                        pass
                 return AgentResult(response=content)
+
+            # Turn record hook.
+            if _capture is not None and _conv_id and content:
+                try:
+                    _capture.record(
+                        _conv_id, author="assistant", content=content,
+                        capture_source="ollama_agent",
+                    )
+                except Exception:
+                    pass
 
             # Append assistant message with tool calls
             messages.append(msg)
@@ -264,8 +346,24 @@ async def run(
                     "content": result_text,
                 })
 
+                # Turn record hook.
+                if _capture is not None and _conv_id:
+                    try:
+                        _capture.record(
+                            _conv_id, author="tool", content=result_text,
+                            capture_source="ollama_agent",
+                        )
+                    except Exception:
+                        pass
+
         return AgentResult(
             response="", error="Reached max tool-call iterations without a final answer."
         )
     finally:
         await bridge.stop()
+        # Session state hook.
+        if _capture is not None:
+            try:
+                await _capture.stop()
+            except Exception:
+                pass

--- a/ollama/src/mnemosyne_ollama/cli.py
+++ b/ollama/src/mnemosyne_ollama/cli.py
@@ -143,18 +143,37 @@ def _run_interactive(args: argparse.Namespace) -> None:
     print("Ctrl+C or Ctrl+D to exit.\n")
 
     async def _session():
+        # Optional runtime integration point.
+        _capture = None
+        _conv_id = None
+        try:
+            from mnemosyne_capture.capture import Capture
+            _capture = Capture(Path(root))
+            await _capture.start()
+            _conv_id = _capture.new_conversation(source="ollama_interactive", model_id=model)
+        except ImportError:
+            pass
+        except Exception:
+            _capture = None
+
         bridge = McpBridge()
         try:
             await bridge.start()
         except FileNotFoundError:
             print("Error: mnemosyne-mcp not found. Install: pip install mnemosyne-mcp", file=sys.stderr)
+            # Session state hook.
+            if _capture is not None:
+                try:
+                    await _capture.stop()
+                except Exception:
+                    pass
             return
 
         try:
             tools = bridge.get_tools_for_ollama()
             messages = [
                 {"role": "system", "content": SYSTEM_PROMPT.format(
-                    project_root=root, budget=args.budget
+                    project_root=root, budget=args.budget, model=model
                 )},
             ]
             loop = asyncio.get_running_loop()
@@ -166,6 +185,16 @@ def _run_interactive(args: argparse.Namespace) -> None:
                     break
                 if not query.strip():
                     continue
+
+                # Turn record hook.
+                if _capture is not None and _conv_id:
+                    try:
+                        _capture.record(
+                            _conv_id, author="user", content=query,
+                            capture_source="ollama_interactive",
+                        )
+                    except Exception:
+                        pass
 
                 messages.append({"role": "user", "content": query})
 
@@ -181,8 +210,27 @@ def _run_interactive(args: argparse.Namespace) -> None:
                     if not tool_calls:
                         if content:
                             print(f"\n{content}\n")
+                        # Turn record hook.
+                        if _capture is not None and _conv_id and content:
+                            try:
+                                _capture.record(
+                                    _conv_id, author="assistant", content=content,
+                                    capture_source="ollama_interactive",
+                                )
+                            except Exception:
+                                pass
                         messages.append({"role": "assistant", "content": content})
                         break
+
+                    # Turn record hook.
+                    if _capture is not None and _conv_id and content:
+                        try:
+                            _capture.record(
+                                _conv_id, author="assistant", content=content,
+                                capture_source="ollama_interactive",
+                            )
+                        except Exception:
+                            pass
 
                     messages.append(msg)
                     for tc in tool_calls:
@@ -197,9 +245,33 @@ def _run_interactive(args: argparse.Namespace) -> None:
                         if args.verbose:
                             print(f"  [tool] {name}({json.dumps(arguments, indent=None)})", file=sys.stderr)
                         result_text = await bridge.call_tool(name, arguments)
+                        # Turn record hook.
+                        if _capture is not None and _conv_id:
+                            try:
+                                _capture.record(
+                                    _conv_id, author="tool", content=result_text,
+                                    capture_source="ollama_interactive",
+                                )
+                            except Exception:
+                                pass
                         messages.append({"role": "tool", "content": result_text})
         finally:
             await bridge.stop()
+            # Optional session finalization hook.
+            if _capture is not None and _conv_id:
+                try:
+                    _capture.store.set_conversation_state(_conv_id, "closed")
+                    from mnemosyne_capture.summarizer_l3 import summarize_conversation
+                    print("[mnemosyne-ollama] finalizing session...", file=sys.stderr)
+                    summarize_conversation(_capture.store, _conv_id, model=model)
+                except Exception:
+                    pass
+            # Session state hook.
+            if _capture is not None:
+                try:
+                    await _capture.stop()
+                except Exception:
+                    pass
 
     try:
         asyncio.run(_session())


### PR DESCRIPTION
## Summary

Wire guarded optional integration hooks into mnemosyne-ollama's agent loop,
interactive CLI, and the mnemosyne-mcp server. Each hook checks at runtime
for an optional sibling Python package; when present, turn-level events and
tool invocations are forwarded to it.

## Changes

- `ollama/src/mnemosyne_ollama/agent.py` (+102): integration points in
  `run()` -- session init, per-turn event forwarding (user, assistant,
  tool), optional context pre-load before the first model call, optional
  session finalization, and session cleanup.

- `ollama/src/mnemosyne_ollama/cli.py` (+74): same integration pattern
  inside `_run_interactive` for interactive sessions.

- `mcp/src/mnemosyne_mcp/server.py` (+94 / -17): module-level session
  state, async `_start_capture` / `_stop_capture` wrapping `main()`, and
  `call_tool` middleware that forwards the tool invocation and result
  around the dispatcher. The dispatcher body is refactored to try/finally
  to accommodate the post-result forwarding step.

- `SYSTEM_PROMPT` gains a `{model}` template variable so integrations can
  read the current session model from the formatted prompt. Both in-repo
  callers (`agent.run` and `cli._run_interactive`) are updated to pass it.

## Test plan

- [x] `python -m py_compile` passes on all three modified files
- [x] Diff shape matches expectation (+253 / -17 across 3 files)
- [x] Manual smoke with sibling package installed: verify events flow through
- [x] Manual smoke without sibling package: verify no import errors
