### PR TITLE
fix: expose brace-family and C/C++ extensions in default supported_extensions

### DIFF
--- a/mnemosyne/chunkers/__init__.py
+++ b/mnemosyne/chunkers/__init__.py
@@ -38,6 +38,8 @@ LANGUAGE_MAP: dict[str, str] = {
     ".py": "python",
     ".js": "javascript",
     ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
     ".ts": "typescript",
     ".tsx": "typescript",
     ".go": "go",

--- a/mnemosyne/config.py
+++ b/mnemosyne/config.py
@@ -62,9 +62,31 @@ DEFAULTS: dict[str, dict[str, Any]] = {
         ],
         "max_file_size_kb": 512,
         "supported_extensions": [
+            # Python / JS / TS -- dedicated structural chunkers
             ".py",
             ".js",
+            ".jsx",
             ".ts",
+            ".tsx",
+            ".mjs",
+            ".cjs",
+            # Brace-family languages with dedicated structural chunkers
+            # (see mnemosyne/chunkers/__init__.py get_chunker dispatch)
+            ".go",
+            ".cs",
+            ".rs",
+            ".java",
+            ".kt",
+            # C / C++ -- LANGUAGE_MAP tagged; chunked by GenericChunker
+            # until a dedicated C chunker ships. Still strictly better
+            # than silent exclusion.
+            ".c",
+            ".h",
+            ".cpp",
+            ".hpp",
+            # Markup / vector graphics -- LANGUAGE_MAP tagged markup.
+            ".svg",
+            # Prose / config
             ".md",
             ".txt",
             ".json",
@@ -75,8 +97,6 @@ DEFAULTS: dict[str, dict[str, Any]] = {
             ".sh",
             ".html",
             ".css",
-            ".jsx",
-            ".tsx",
             # Document formats (Tier 0 -- text extraction)
             ".pdf",
             ".docx",

--- a/mnemosyne/tests/test_brace_chunkers.py
+++ b/mnemosyne/tests/test_brace_chunkers.py
@@ -626,6 +626,10 @@ class TestRegistryDispatch(unittest.TestCase):
         self.assertEqual(detect_language("main.cpp"), "cpp")
         self.assertEqual(detect_language("header.h"), "c")
         self.assertEqual(detect_language("header.hpp"), "cpp")
+        # ESM / CommonJS variants of JavaScript must route through
+        # JSChunker, not fall through to GenericChunker.
+        self.assertEqual(detect_language("esm-module.mjs"), "javascript")
+        self.assertEqual(detect_language("legacy.cjs"), "javascript")
 
     def test_unknown_extension_still_generic(self):
         from mnemosyne.chunkers import get_chunker

--- a/mnemosyne/tests/test_core.py
+++ b/mnemosyne/tests/test_core.py
@@ -15,6 +15,7 @@ import sqlite3
 import struct
 import tempfile
 import unittest
+from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +47,54 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(cfg.general.max_file_size_kb, 512)
             self.assertIsInstance(cfg.general.supported_extensions, list)
             self.assertIn(".py", cfg.general.supported_extensions)
+
+    def test_default_extensions_cover_brace_family_languages(self):
+        """Regression guard: supported_extensions must expose every
+        language the chunker dispatcher already handles structurally.
+        Historically the defaults were Python/Node-flavoured and
+        silently filtered .cs / .rs / .go / .java / .kt / .c / .cpp
+        out of every ingest even though dedicated chunkers existed.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._make_config(root=tmp)
+            exts = cfg.general.supported_extensions
+            # Dedicated structural chunkers exist for these.
+            for required in (
+                ".cs", ".rs", ".go", ".java", ".kt",
+                ".mjs", ".cjs",
+            ):
+                self.assertIn(
+                    required,
+                    exts,
+                    msg=f"{required} missing from default supported_extensions",
+                )
+            # LANGUAGE_MAP-tagged (chunked by GenericChunker today, but
+            # still strictly better than silent exclusion).
+            for tagged in (".c", ".h", ".cpp", ".hpp", ".svg"):
+                self.assertIn(
+                    tagged,
+                    exts,
+                    msg=f"{tagged} missing from default supported_extensions",
+                )
+
+    def test_user_config_supported_extensions_unions_with_defaults(self):
+        """A user config.toml that sets supported_extensions must not
+        drop .cs et al. from the effective list -- the deep-merge is
+        list-union, so hardened language coverage is preserved even
+        when a project overrides the list with its own additions.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            mnemo_dir = Path(tmp) / ".mnemosyne"
+            mnemo_dir.mkdir(parents=True, exist_ok=True)
+            (mnemo_dir / "config.toml").write_text(
+                '[general]\nsupported_extensions = [".xyz"]\n',
+                encoding="utf-8",
+            )
+            cfg = self._make_config(root=tmp)
+            exts = cfg.general.supported_extensions
+            self.assertIn(".xyz", exts, "user addition must land")
+            self.assertIn(".cs", exts, "default .cs must survive user override")
+            self.assertIn(".py", exts, "default .py must survive user override")
 
     def test_get_method(self):
         """config.get(section, key) returns the correct value."""


### PR DESCRIPTION
## Summary
- Engine shipped dedicated chunkers for C#, Rust, Go, Java, Kotlin (and LANGUAGE_MAP for C/C++/SVG) but `DEFAULTS.general.supported_extensions` in `config.py` only listed
Python/JS/TS/prose. The ingester's extension gate silently rejected every `.cs`/`.rs`/`.go`/`.java`/`.cpp` file before the chunker saw it.
- Adds `.mjs`, `.cjs`, `.go`, `.cs`, `.rs`, `.java`, `.kt`, `.c`, `.h`, `.cpp`, `.hpp`, `.svg` to defaults. Routes `.mjs`/`.cjs` through `JSChunker`.
- `Config._deep_merge` unions list-typed sections, so this fix retroactively applies to existing `.mnemosyne/config.toml` files at load time -- users don't need to edit their own
configs.

## Test plan
- [ ] Fresh `mnemosyne init` in a C# / Rust / Go / Java project. Run `mnemosyne index`. Confirm non-zero file count indexed.
- [ ] Existing `.mnemosyne/config.toml` with custom `supported_extensions` -- confirm new extensions appear after load via `mnemosyne stats`.
- [ ] Run full pytest suite. Expect 448 tests, zero regressions.
- [ ] `test_default_extensions_cover_brace_family_languages` and `test_user_config_supported_extensions_unions_with_defaults` pass.