### PR TITLE
fix(config): extend default ignore_patterns for build outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Mnemosyne are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Default `general.ignore_patterns` extended to cover common build-output
+  directories and runtime artifacts that the prior set silently allowed
+  into the index. Triggering case: a .NET project whose
+  `bin/Release/*.deps.json` and `*.runtimeconfig.json` files (NuGet
+  build manifests, hundreds of KB of high-IDF JSON) ended up dominating
+  BM25 scoring on unrelated queries -- the doc-retrieval lane would
+  surface a build manifest as a top cite for prompts that had nothing
+  to do with .NET.
+
+  Additions:
+  - Generic build dirs: `bin`, `obj`, `target`, `build`, `dist`, `out`,
+    `vendor`, `cmake-build-*`, `htmlcov`, `*.egg-info`
+  - Compiled artifacts: `*.class`, `*.jar`, `*.war`, `*.ear`, `*.dll`,
+    `*.exe`, `*.pdb`, `*.dylib`, `*.so`, `*.o`, `*.a`
+  - .NET runtime descriptors: `*.deps.json`, `*.runtimeconfig.json`,
+    `*.runtimeconfig.dev.json`
+  - TypeScript build cache: `*.tsbuildinfo`
+
+  The hidden-dir glob (`.*`) already covered `.venv`, `.pytest_cache`,
+  `.mypy_cache`, `.tox`, `.gradle`, `.next`, `.nuxt`, `.cache`,
+  `.dotnet`, etc. -- comment expanded for clarity, no behavior change
+  there.
+
+  User-config semantics unchanged: a project that defines its own
+  `general.ignore_patterns` in `.mnemosyne/config.toml` still wins via
+  the existing list-union deep-merge.
+
+  **Behavior change for already-indexed projects:** a re-index
+  (`mnemosyne ingest --full`) is required to evict polluted rows.
+  Projects that intentionally indexed files matching the new patterns
+  (rare but possible: a `bin/` directory of shell scripts, or
+  compliance scans against `*.deps.json`) can override by setting
+  `general.ignore_patterns` in `.mnemosyne/config.toml`.
+
 ## [1.1.0] - 2026-04-07
 
 ### Added

--- a/mnemosyne/config.py
+++ b/mnemosyne/config.py
@@ -26,17 +26,52 @@ DEFAULTS: dict[str, dict[str, Any]] = {
         "project_root": ".",
         "ignore_patterns": [
             # Hidden directories and files -- catches .git, .mnemosyne,
-            # .env, .ssh, .aws, .vscode, .idea, .github, etc.
+            # .env, .ssh, .aws, .vscode, .idea, .github, .venv,
+            # .pytest_cache, .mypy_cache, .tox, .next, .nuxt, .gradle,
+            # .cache, .dotnet, etc.
             ".*",
-            # Build artifacts
+            # Generic build / output directories across many languages.
+            # `bin` and `obj` matter most for .NET; previously absent and
+            # caused massive .deps.json blobs to dominate BM25.
             "node_modules",
             "__pycache__",
             "mnemosyne",
+            "bin",
+            "obj",
+            "target",
+            "build",
+            "dist",
+            "out",
+            "vendor",
+            "cmake-build-*",
+            "htmlcov",
+            "*.egg-info",
+            # Compiled / runtime artifacts. Source projects rarely
+            # commit these; when they do, indexing them adds noise
+            # without adding signal.
             "*.pyc",
+            "*.class",
+            "*.jar",
+            "*.war",
+            "*.ear",
+            "*.dll",
+            "*.exe",
+            "*.pdb",
+            "*.dylib",
+            "*.so",
+            "*.o",
+            "*.a",
+            # .NET runtime descriptors that are not source.
+            "*.deps.json",
+            "*.runtimeconfig.json",
+            "*.runtimeconfig.dev.json",
+            # TypeScript build cache.
+            "*.tsbuildinfo",
+            # Lockfiles + minified bundles.
             "*.lock",
             "*.min.js",
             "*.min.css",
-            # Secrets and credentials
+            # Secrets and credentials.
             "*.pem",
             "*.key",
             "*.p12",
@@ -57,7 +92,7 @@ DEFAULTS: dict[str, dict[str, Any]] = {
             "token.json",
             "*.token",
             "*.tfvars",
-            # Common non-source noise
+            # Common non-source noise.
             "package-lock.json",
         ],
         "max_file_size_kb": 512,

--- a/mnemosyne/tests/test_core.py
+++ b/mnemosyne/tests/test_core.py
@@ -77,6 +77,45 @@ class TestConfig(unittest.TestCase):
                     msg=f"{tagged} missing from default supported_extensions",
                 )
 
+    def test_default_ignore_patterns_cover_build_outputs(self):
+        """Regression guard: ignore_patterns must hide common build-output
+        directories and runtime artifacts from indexing. Without these,
+        a .NET project's `bin/Release/*.deps.json` (NuGet dependency
+        manifest) ends up in the doc store with high-IDF tokens that
+        dominate BM25 scoring on unrelated queries -- the precise
+        failure mode that triggered this hardening.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._make_config(root=tmp)
+            patterns = cfg.general.ignore_patterns
+            # .NET noise that triggered the rework.
+            for required in ("bin", "obj", "*.deps.json",
+                             "*.runtimeconfig.json"):
+                self.assertIn(
+                    required,
+                    patterns,
+                    msg=f"{required} missing from default ignore_patterns",
+                )
+            # Generic build dirs across many languages.
+            for required in ("node_modules", "__pycache__", "target",
+                             "build", "dist", "out", "vendor",
+                             "cmake-build-*", "htmlcov", "*.egg-info"):
+                self.assertIn(
+                    required,
+                    patterns,
+                    msg=f"{required} missing from default ignore_patterns",
+                )
+            # Compiled artifacts that should not be indexed even when
+            # checked in.
+            for required in ("*.class", "*.jar", "*.dll", "*.exe",
+                             "*.pdb", "*.so", "*.dylib",
+                             "*.tsbuildinfo"):
+                self.assertIn(
+                    required,
+                    patterns,
+                    msg=f"{required} missing from default ignore_patterns",
+                )
+
     def test_user_config_supported_extensions_unions_with_defaults(self):
         """A user config.toml that sets supported_extensions must not
         drop .cs et al. from the effective list -- the deep-merge is


### PR DESCRIPTION
Adds the build-output dirs and runtime-artifact globs that the prior default set silently allowed into the index. The triggering case was a .NET project whose `bin/Release/*.deps.json` and `*.runtimeconfig.json` files (NuGet build manifests, hundreds of KB of high-IDF JSON) ended up dominating BM25 scoring on unrelated queries -- the doc-retrieval lane would surface a build manifest as a top cite for prompts that had nothing to do with .NET.

Additions:
- Generic build dirs: bin, obj, target, build, dist, out, vendor, cmake-build-*, htmlcov, *.egg-info
- Compiled artifacts: *.class, *.jar, *.war, *.ear, *.dll, *.exe, *.pdb, *.dylib, *.so, *.o, *.a
- .NET runtime descriptors: *.deps.json, *.runtimeconfig.json, *.runtimeconfig.dev.json
- TypeScript build cache: *.tsbuildinfo

Hidden-dir glob (`.*`) already covers `.venv`, `.pytest_cache`, `.mypy_cache`, `.tox`, `.gradle`, `.next`, `.nuxt`, `.cache`, `.dotnet`, etc. -- comment expanded for clarity but no behavior change there.

User-config semantics unchanged: a project that defines its own `general.ignore_patterns` in `.mnemosyne/config.toml` still wins via the existing list-union deep-merge.

Behavior change for already-indexed projects: re-index is required to evict polluted rows. Projects that intentionally indexed files matching the new patterns can override via .mnemosyne/config.toml.

Tests:
- New `test_default_ignore_patterns_cover_build_outputs` regression guard in TestConfig (mnemosyne/tests/test_core.py).
- 458 / 458 engine tests green (was 457).