### PR TITLE
feat(config): bump default max_file_size_kb from 512 to 1024

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -150,7 +150,7 @@ preserve_docstrings = true
 
 [general]
 ignore_patterns = [".git", "node_modules", "__pycache__", ".mnemosyne"]
-max_file_size_kb = 512
+max_file_size_kb = 1024
 ```
 
 The `budget` parameter in `mnemosyne.search` overrides `token_budget` on a per-query basis.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -72,7 +72,7 @@ Key settings to consider adjusting:
 ignore_patterns = [".git", "node_modules", "__pycache__", ".mnemosyne", "*.pyc", "*.lock"]
 
 # Max file size to index (skip large generated files)
-max_file_size_kb = 512
+max_file_size_kb = 1024
 
 # File types to index
 supported_extensions = [".py", ".js", ".ts", ".md", ".txt", ".json", ".yaml", ".sql", ".sh", ".html", ".css"]
@@ -408,6 +408,6 @@ echo "=== ALL TESTS PASSED ==="
 | `0 chunks, 0 tokens` on query | Run `mnemosyne ingest` first -- the index is empty |
 | All files skipped on ingest | Run `mnemosyne ingest --full` to force re-index |
 | File type not indexed | Add the extension to `supported_extensions` in `.mnemosyne/config.toml` |
-| Large files skipped | Increase `max_file_size_kb` in config (default: 512 KB) |
+| Large files skipped | Increase `max_file_size_kb` in config (default: 1024 KB) |
 | Query returns too few results | Lower the `--budget` or adjust `retrieval.max_results` in config |
 | `python3 -m mnemosyne` not found | Ensure you're in the right directory or `PYTHONPATH` is set |

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -483,7 +483,7 @@ Configuration is read from `.mnemosyne/config.toml` in the project root, deep-me
 |---|---|---|
 | `project_root` | `"."` | Root directory to scan (relative to config file location). |
 | `ignore_patterns` | `[".git", "node_modules", "__pycache__", ...]` | fnmatch patterns for files and directories to skip. |
-| `max_file_size_kb` | `512` | Files larger than this are skipped during ingestion. |
+| `max_file_size_kb` | `1024` | Files larger than this are skipped during ingestion. |
 | `supported_extensions` | `[".py", ".js", ".ts", ".go", ".cs", ".rs", ".java", ".kt", ".md", ...]` | File extensions to index. |
 
 ### `[chunking]`
@@ -1253,7 +1253,7 @@ Configuration is read from `.mnemosyne/config.toml` in the project root, deep-me
 |---|---|---|
 | `project_root` | `"."` | Root directory to scan (relative to config file location). |
 | `ignore_patterns` | `[".git", "node_modules", "__pycache__", ...]` | fnmatch patterns for files and directories to skip. |
-| `max_file_size_kb` | `512` | Files larger than this are skipped during ingestion. |
+| `max_file_size_kb` | `1024` | Files larger than this are skipped during ingestion. |
 | `supported_extensions` | `[".py", ".js", ".ts", ".go", ".cs", ".rs", ".java", ".kt", ".md", ...]` | File extensions to index. |
 
 ### `[chunking]`

--- a/mnemosyne/config.py
+++ b/mnemosyne/config.py
@@ -95,7 +95,7 @@ DEFAULTS: dict[str, dict[str, Any]] = {
             # Common non-source noise.
             "package-lock.json",
         ],
-        "max_file_size_kb": 512,
+        "max_file_size_kb": 1024,
         "supported_extensions": [
             # Python / JS / TS -- dedicated structural chunkers
             ".py",

--- a/mnemosyne/tests/test_core.py
+++ b/mnemosyne/tests/test_core.py
@@ -44,7 +44,7 @@ class TestConfig(unittest.TestCase):
         """config.general.max_file_size_kb is accessible."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = self._make_config(root=tmp)
-            self.assertEqual(cfg.general.max_file_size_kb, 512)
+            self.assertEqual(cfg.general.max_file_size_kb, 1024)
             self.assertIsInstance(cfg.general.supported_extensions, list)
             self.assertIn(".py", cfg.general.supported_extensions)
 


### PR DESCRIPTION
512 KB is too tight for modern monorepos. Real-world hit on Plimsoll: app/src/event_loop.rs has grown to 533 KB and was being silently skipped

Changes
-------
- mnemosyne/config.py: DEFAULTS["general"]["max_file_size_kb"] 512 -> 1024
- mnemosyne/tests/test_core.py: assertion updated to match
- MCP.md, PLAYBOOK.md, REFERENCE.md: example configs and docs updated

Test results
------------
- mnemosyne/tests/test_core.py: 43 passed

Operator note
-------------
Existing projects keep their old config.toml value (512) until the operator re-runs `mnemosyne init` or hand-edits the file. Only fresh init runs and freshly-generated configs get 1024.