### PR TITLE
feat(config+ingest): long-tail supported_extensions + files_by_extension stat

### DIFF
--- a/mnemosyne/config.py
+++ b/mnemosyne/config.py
@@ -144,6 +144,58 @@ DEFAULTS: dict[str, dict[str, Any]] = {
             ".conf",
             ".rst",
             ".xml",
+            # Mobile / Apple ecosystem -- LANGUAGE_MAP-tagged but
+            # historically excluded by default; chunked by
+            # GenericChunker until dedicated structural chunkers ship.
+            ".swift",
+            ".kts",  # Kotlin script
+            ".dart",
+            # C / C++ alternates the LANGUAGE_MAP recognizes but the
+            # prior list missed.
+            ".cc",
+            ".cxx",
+            ".hh",
+            ".hxx",
+            # Functional languages -- GenericChunker fallback. Adding
+            # so a user with a Haskell/OCaml/Erlang/F#/Elixir project
+            # is not silently filtered out.
+            ".hs",
+            ".ml",
+            ".mli",
+            ".erl",
+            ".hrl",
+            ".fs",
+            ".fsi",
+            ".ex",
+            ".exs",
+            # Scripting languages frequently encountered in mixed
+            # repos but absent from the prior Python/Node-flavoured
+            # default.
+            ".rb",
+            ".php",
+            ".scala",
+            ".sc",
+            ".lua",
+            ".r",
+            ".R",
+            ".pl",
+            ".pm",
+            # Web frameworks with single-file component shapes.
+            ".vue",
+            ".svelte",
+            # Systems languages.
+            ".nix",
+            ".zig",
+            # Shells beyond .sh -- the brace-family / completion
+            # variants real shops actually use.
+            ".bash",
+            ".zsh",
+            ".fish",
+            # Schema-definition formats commonly checked into
+            # service repos.
+            ".proto",
+            ".graphql",
+            ".gql",
         ],
     },
     "chunking": {

--- a/mnemosyne/ingest.py
+++ b/mnemosyne/ingest.py
@@ -93,11 +93,15 @@ class Ingester:
         Returns:
             Stats dict with keys ``files_scanned``, ``files_indexed``,
             ``files_skipped``, ``files_failed``, ``chunks_added``,
-            ``chunks_deduped``, ``elapsed_seconds``.
+            ``chunks_deduped``, ``elapsed_seconds``, and
+            ``files_by_extension`` (a ``dict[str, int]`` keyed by
+            lowercased extension string -- ``".py"``, ``".rs"``,
+            ``"(no-ext)"`` for extensionless files -- with file counts
+            from the resolved scan list).
         """
         t_start = time.monotonic()
 
-        stats: dict[str, int | float] = {
+        stats: dict[str, int | float | dict[str, int]] = {
             "files_scanned": 0,
             "files_indexed": 0,
             "files_skipped": 0,
@@ -105,6 +109,12 @@ class Ingester:
             "chunks_added": 0,
             "chunks_deduped": 0,
             "elapsed_seconds": 0.0,
+            # Per-extension count of files in the resolved scan list.
+            # Built once after _scan_files / _resolve_paths returns so
+            # the cost is a single pass over file_list (no extra IO).
+            # Surfaces in dry-run / preview output so callers can see
+            # WHAT they're about to ingest, not just the totals.
+            "files_by_extension": {},
         }
 
         # Resolve file list
@@ -114,6 +124,16 @@ class Ingester:
             file_list = self._scan_files()
 
         stats["files_scanned"] = len(file_list)
+        # Per-extension tally on the resolved scan list. Honors the
+        # exact set of files the ingester will actually walk -- so the
+        # breakdown reflects ignore_patterns + supported_extensions
+        # filtering already applied by _scan_files.
+        ext_counts: dict[str, int] = {}
+        for abs_path in file_list:
+            _, ext = os.path.splitext(abs_path)
+            ext_lower = ext.lower() or "(no-ext)"
+            ext_counts[ext_lower] = ext_counts.get(ext_lower, 0) + 1
+        stats["files_by_extension"] = ext_counts
 
         # On full re-index of the entire project, purge stale file records
         # (files that were previously indexed but are no longer in the scan

--- a/mnemosyne/tests/test_core.py
+++ b/mnemosyne/tests/test_core.py
@@ -77,6 +77,45 @@ class TestConfig(unittest.TestCase):
                     msg=f"{tagged} missing from default supported_extensions",
                 )
 
+    def test_default_extensions_cover_long_tail_languages(self):
+        """Regression guard: the default supported_extensions must
+        cover the long tail of language ecosystems, not just the
+        Python/Node/brace-family core. Previously a user opening
+        mnemosyne against a Swift/Ruby/Elixir/Vue/Nix/Proto project
+        would see 'no files indexed' because the default extension
+        list silently filtered everything.
+
+        Each category exists for a real reason: someone has a project
+        in that ecosystem and expects mnemosyne to work without
+        hand-editing config.toml first.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._make_config(root=tmp)
+            exts = cfg.general.supported_extensions
+            categories = {
+                "mobile/Apple": (".swift", ".kts", ".dart"),
+                "C/C++ alternates": (".cc", ".cxx", ".hh", ".hxx"),
+                "functional": (
+                    ".hs", ".ml", ".mli", ".erl", ".hrl",
+                    ".fs", ".fsi", ".ex", ".exs",
+                ),
+                "scripting": (
+                    ".rb", ".php", ".scala", ".sc", ".lua",
+                    ".r", ".R", ".pl", ".pm",
+                ),
+                "web frameworks": (".vue", ".svelte"),
+                "systems": (".nix", ".zig"),
+                "shells beyond sh": (".bash", ".zsh", ".fish"),
+                "schemas": (".proto", ".graphql", ".gql"),
+            }
+            for category, required in categories.items():
+                for ext in required:
+                    self.assertIn(
+                        ext,
+                        exts,
+                        msg=f"{ext} ({category}) missing from default supported_extensions",
+                    )
+
     def test_default_ignore_patterns_cover_build_outputs(self):
         """Regression guard: ignore_patterns must hide common build-output
         directories and runtime artifacts from indexing. Without these,

--- a/mnemosyne/tests/test_doc_ingest_integration.py
+++ b/mnemosyne/tests/test_doc_ingest_integration.py
@@ -121,6 +121,42 @@ class TestDocumentIngestion:
         assert stats["files_indexed"] > 0
         assert stats["files_failed"] == 0
 
+    def test_ingest_stats_include_files_by_extension(self, engine):
+        """Per-extension breakdown must be present + match files_scanned.
+
+        Added so a dry-run / ingest-preview surface can show "what
+        would be ingested by extension", not just total counts.
+        Plumbed here so a single engine ingest call carries enough
+        info; no caller has to reproduce the scan.
+        """
+        ingester, _store, _doc_store, _config = engine
+        stats = ingester.ingest()
+
+        assert "files_by_extension" in stats, "missing per-extension stat"
+        by_ext = stats["files_by_extension"]
+        assert isinstance(by_ext, dict)
+        # Sum of per-extension counts must equal files_scanned (every
+        # file in the resolved scan list contributes exactly one
+        # extension count).
+        assert sum(by_ext.values()) == stats["files_scanned"]
+        # Test fixture writes .docx, .log, .ini files; at least those
+        # should appear in the breakdown.
+        for ext in (".docx", ".log", ".ini"):
+            assert ext in by_ext, f"{ext} missing from files_by_extension {by_ext!r}"
+
+    def test_ingest_dry_run_populates_files_by_extension(self, engine):
+        """Dry-run path must produce the same extension breakdown as
+        a real ingest -- because the per-extension stat is built off
+        the resolved scan list, not the indexing loop's writes.
+        """
+        ingester, _store, _doc_store, _config = engine
+        stats = ingester.ingest(dry_run=True)
+        by_ext = stats["files_by_extension"]
+        assert isinstance(by_ext, dict)
+        assert sum(by_ext.values()) == stats["files_scanned"]
+        # Dry-run still tallies every scanned file's extension.
+        assert len(by_ext) > 0
+
     def test_csv_chunks_in_doc_partition(self, engine):
         ingester, store, doc_store, config = engine
         ingester.ingest()


### PR DESCRIPTION
## What

1. Extends default `supported_extensions` with 35 long-tail languages
 the prior Python/Node/brace-family list silently filtered out
 (.swift/.kts/.dart, functional langs, .rb/.php/.scala/.lua,
 .vue/.svelte, .nix/.zig, alternate shells, .proto/.graphql/.gql,
 C/C++ alternates).

2. Adds `files_by_extension: dict[str,int]` to `Ingester.ingest`
 stats. Single-pass tally over the resolved scan list; honors the
 same ignore_patterns + supported_extensions filtering.

## Why

Discovered by the Plimsoll team during fresh-project onboarding:
a user opening mnemosyne in a Swift/Ruby/Vue/.NET project saw
"0 files indexed" because the default extension list omitted the
language. Plimsoll briefly carried a parallel seed config to
compensate; the canonical fix is here in the engine so no
downstream consumer has to duplicate the list.

files_by_extension supports Plimsoll's /onboard-preview which shows
a per-extension breakdown of what would be ingested.

## Tests

test_core.py: test_default_extensions_cover_long_tail_languages
test_doc_ingest_integration.py: files_by_extension present on real
ingest AND dry-run; sum equals files_scanned.
Full suite green (63 across config/ingest/paths).

Backwards-compatible: deep_merge is list-union; existing user
configs see the new defaults unioned in.