### PR TITLE
Semantic conversation-recall embedder (bge-small int8 ONNX, CPU) + generic  vector helper

### DIFF
--- a/mnemosyne/config.py
+++ b/mnemosyne/config.py
@@ -211,6 +211,15 @@ DEFAULTS: dict[str, dict[str, Any]] = {
         "dense_model": None,  # "minilm-l6-code" to enable, None to disable
         "dense_dim": 384,
         "dense_weight": 0.3,
+        # Optional 384-dim semantic backend (BGE-small ONNX, [dense] extra).
+        # Set a truthy id (e.g. "bge-small-en-v1.5") to enable; None disables.
+        "semantic_model": None,
+        # Override the project-owned artifact host; None uses the module default
+        # / the MNEMOSYNE_SEMANTIC_MODEL_REPO env var.
+        "semantic_model_repo": None,
+        # Offline: directory holding a pre-placed model_quantized.onnx +
+        # tokenizer.json.  When set, the network is never contacted.
+        "semantic_local_path": None,
     },
     "compression": {
         "target_ratio": 0.4,

--- a/mnemosyne/embeddings/__init__.py
+++ b/mnemosyne/embeddings/__init__.py
@@ -56,4 +56,43 @@ def get_dense_backend(config: "Config", store=None, model_dir: str | None = None
         return None
 
 
-__all__ = ["TFIDFBackend", "get_backend", "get_dense_backend"]
+def get_semantic_backend(
+    config: "Config",
+    *,
+    cache_dir: str | None = None,
+    local_path: str | None = None,
+    base_url: str | None = None,
+):
+    """Return the BGE-small semantic embedding backend, or ``None``.
+
+    Returns ``None`` when the semantic backend is not enabled in config
+    (``embedding.semantic_model`` falsy) so the caller can fall back to the
+    lighter lanes.  The instance itself degrades gracefully (``embed`` returns
+    ``None`` when onnxruntime/numpy or the model artifact is missing), so it is
+    safe to construct even when those are absent.
+
+    Args:
+        config:     Mnemosyne :class:`~mnemosyne.config.Config` instance.
+        cache_dir:  Override the shared model cache directory.
+        local_path: Offline directory of pre-placed model files (skips network).
+        base_url:   Override the artifact base URL.
+
+    Returns:
+        A :class:`~mnemosyne.embeddings.semantic_backend.SemanticBackend`, or
+        ``None`` if not enabled.
+    """
+    if not getattr(config.embedding, "semantic_model", None):
+        return None
+    from mnemosyne.embeddings.semantic_backend import SemanticBackend
+
+    return SemanticBackend(
+        config, cache_dir=cache_dir, local_path=local_path, base_url=base_url
+    )
+
+
+__all__ = [
+    "TFIDFBackend",
+    "get_backend",
+    "get_dense_backend",
+    "get_semantic_backend",
+]

--- a/mnemosyne/embeddings/semantic_backend.py
+++ b/mnemosyne/embeddings/semantic_backend.py
@@ -21,19 +21,24 @@ Why a separate module from ``dense_backend``:
 
 Model artifact (sourcing contract)
 -----------------------------------
-The model is NOT bundled in this repository and is NOT downloaded from a
-personal account.  A maintainer converts + quantizes the official BAAI weights
-ONCE (see ``tools/convert_bge_small_onnx.py``), hosts the result at a
-PROJECT-OWNED location, and pins it here:
+The model is NOT bundled in this repository.  It is the vetted, pre-built int8
+ONNX export of BAAI/bge-small-en-v1.5 maintained by the reputable HF-staff
+Xenova account -- a single quantized file, no local conversion step.  It is
+pinned to an immutable commit and SHA-verified here:
 
-    * MODEL_REPO / MODEL_BASE_URL -- where the artifact lives.  A placeholder
-      default ships; set the real value on publish (or override via config /
-      the ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env var / ``base_url`` argument).
-    * MODEL_REVISION -- pin to a SPECIFIC immutable commit hash on publish.
-    * MODEL_SHA256 / TOKENIZER_SHA256 -- the exact hashes the conversion tool
-      printed.  When set, downloads are verified and REJECTED + deleted on
-      mismatch.  When None, a LOUD warning is emitted (unpinned / unverified).
-    * MODEL_FILENAME / TOKENIZER_FILENAME -- the quantized onnx + tokenizer.
+    * MODEL_REPO / MODEL_BASE_URL -- the artifact repository base URL.  Defaults
+      to ``https://huggingface.co/Xenova/bge-small-en-v1.5``.  Override via
+      config ``semantic_model_repo`` / the ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env
+      var / the ``base_url`` argument (a mirror must serve the same
+      ``resolve/<rev>/<path>`` layout).
+    * MODEL_REVISION -- the immutable commit pin.  The download URL is built as
+      ``<repo>/resolve/<rev>/<path>``.
+    * MODEL_SHA256 -- the verified hash of the int8 model; the download is
+      REJECTED + deleted on mismatch.  TOKENIZER_SHA256 is None (the pinned
+      commit makes tokenizer.json immutable; set it on first download to enable
+      verification) so a LOUD warning fires for it until set.
+    * MODEL_FILENAME / TOKENIZER_FILENAME -- the int8 onnx (under ``onnx/``) and
+      the tokenizer; cached locally by basename.
 
 Security model
 --------------
@@ -43,8 +48,8 @@ Security model
   chmod 0600.  On a hash mismatch the partial file is removed and the load
   fails closed.
 - Offline supported: point ``local_path`` at a directory holding pre-placed
-  ``model_quantized.onnx`` + ``tokenizer.json`` and the network is never
-  touched.  An already-cached file is likewise reused without a download.
+  ``model_int8.onnx`` + ``tokenizer.json`` and the network is never touched.
+  An already-cached file is likewise reused without a download.
 - Graceful degradation: if onnxruntime or numpy is missing, the model files
   are unavailable, or the text is empty, every embed call returns ``None`` and
   the caller simply skips this lane.
@@ -73,29 +78,38 @@ logger = logging.getLogger(__name__)
 # Model constants -- the maintainer sets these on artifact publish.
 # ---------------------------------------------------------------------------
 
-#: Project-owned artifact location.  This is a DOCUMENTED PLACEHOLDER -- the
-#: maintainer replaces it (or overrides it at runtime) with the real host they
-#: publish the converted artifact to.  It MUST NOT point at a personal account.
+#: Base URL of the pre-built artifact repository.  Defaults to the vetted,
+#: HF-staff-maintained Xenova int8 ONNX export of BAAI/bge-small-en-v1.5 -- a
+#: single-file quantized model, no conversion step, no personal account.
 #: Override precedence: ``base_url`` arg > config ``semantic_model_repo`` >
-#: ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env var > this default.
-MODEL_REPO: str = "https://models.example-project.invalid/bge-small-en-v1.5"
+#: ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env var > this default.  A custom mirror
+#: must serve the same ``resolve/<rev>/<path>`` layout (HuggingFace style).
+MODEL_REPO: str = "https://huggingface.co/Xenova/bge-small-en-v1.5"
 
 #: Alias kept for callers/readers who think in "base URL" terms.
 MODEL_BASE_URL: str = MODEL_REPO
 
-#: Pin to a SPECIFIC immutable revision/commit when the artifact is published.
-#: A revision path segment is only appended when this is set.
-MODEL_REVISION: str | None = None  # set on artifact publish
+#: Immutable commit pin on the artifact repo.  A revision is ALWAYS used to
+#: build the download URL when set; this makes ``tokenizer.json`` (which has no
+#: SHA pin below) content-addressable, and pins the model bytes we verify.
+MODEL_REVISION: str | None = "ea104dacec62c0de699686887e3f920caeb4f3e3"
 
-#: The quantized ONNX model + the HuggingFace tokenizer.json filenames.
-MODEL_FILENAME: str = "model_quantized.onnx"
+#: Remote paths of the int8 ONNX model + the HuggingFace tokenizer.json,
+#: RELATIVE to ``resolve/<rev>/``.  The model lives under an ``onnx/`` prefix in
+#: the Xenova repo; the local cache file is flattened to its basename (see
+#: :func:`_local_filename`) so offline ``local_path`` dirs stay flat.
+MODEL_FILENAME: str = "onnx/model_int8.onnx"
 TOKENIZER_FILENAME: str = "tokenizer.json"
 
-#: Expected SHA-256 of each artifact.  SET THESE on publish to the values the
-#: conversion tool prints.  When None the download is UNVERIFIED -- a loud
-#: warning fires; do not ship a public release with these unset.
-MODEL_SHA256: str | None = None      # set on artifact publish
-TOKENIZER_SHA256: str | None = None  # set on artifact publish
+#: Expected SHA-256 of each artifact.  The model is SHA-pinned (verified ->
+#: download is REJECTED + deleted on mismatch).  The tokenizer is left None:
+#: the pinned commit makes tokenizer.json immutable; compute its SHA-256 on
+#: first download and set this to enable verification.  (The big-risk file --
+#: the model -- IS SHA-pinned, so the artifact's integrity is checked.)
+MODEL_SHA256: str | None = (
+    "bf64d05457cb391fa88d045faf5927a15ea36d96228ddf23ea970087afdc1197"
+)
+TOKENIZER_SHA256: str | None = None
 
 #: Output dimensionality and max sequence length for bge-small-en-v1.5.
 MODEL_DIM: int = 384
@@ -151,12 +165,32 @@ def _resolve_base_url(config: "Config | None", base_url: str | None) -> str:
 
 
 def _artifact_url(base_url: str, filename: str) -> str:
-    """Join base URL + optional pinned revision + filename into a download URL."""
+    """Build the download URL for ``filename`` from the artifact repo.
+
+    Uses the HuggingFace ``resolve/<rev>/<path>`` layout when a revision is
+    pinned (the default), e.g.::
+
+        https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/<rev>/onnx/model_int8.onnx
+
+    When ``MODEL_REVISION`` is None (a custom flat mirror), the filename is
+    joined directly onto the base URL.  ``filename`` keeps its remote prefix
+    (e.g. ``onnx/...``); only the LOCAL cache path is flattened.
+    """
     parts = [base_url.rstrip("/")]
     if MODEL_REVISION:
-        parts.append(MODEL_REVISION)
-    parts.append(filename)
+        parts.extend(("resolve", MODEL_REVISION))
+    parts.append(filename.lstrip("/"))
     return "/".join(parts)
+
+
+def _local_filename(remote_filename: str) -> str:
+    """Map a remote artifact path to its FLAT local cache filename.
+
+    The remote model path carries an ``onnx/`` prefix; the local cache (and
+    offline ``local_path`` dirs) store the file by basename so no subdirectory
+    is required.  The loader reads exactly the name written here.
+    """
+    return os.path.basename(remote_filename)
 
 
 # ---------------------------------------------------------------------------
@@ -205,11 +239,17 @@ class SemanticBackend:
     # ------------------------------------------------------------------
 
     def _resolve_paths(self) -> tuple[str, str]:
-        """Return (model_path, tokenizer_path) for the active source dir."""
+        """Return (model_path, tokenizer_path) for the active source dir.
+
+        Local files are stored FLAT (by basename), so the remote ``onnx/``
+        prefix on ``MODEL_FILENAME`` is stripped here -- the offline
+        ``local_path`` dir holds ``model_int8.onnx`` + ``tokenizer.json``
+        directly, no ``onnx/`` subdirectory.
+        """
         source_dir = self._local_path or self._cache_dir
         return (
-            os.path.join(source_dir, MODEL_FILENAME),
-            os.path.join(source_dir, TOKENIZER_FILENAME),
+            os.path.join(source_dir, _local_filename(MODEL_FILENAME)),
+            os.path.join(source_dir, _local_filename(TOKENIZER_FILENAME)),
         )
 
     def _ensure_model(self) -> None:
@@ -233,7 +273,8 @@ class SemanticBackend:
             ):
                 raise FileNotFoundError(
                     "semantic model local_path is set but "
-                    f"{MODEL_FILENAME} / {TOKENIZER_FILENAME} were not found "
+                    f"{_local_filename(MODEL_FILENAME)} / "
+                    f"{_local_filename(TOKENIZER_FILENAME)} were not found "
                     f"in {self._local_path!r}"
                 )
         else:
@@ -332,25 +373,19 @@ class SemanticBackend:
 
         outputs = self._session.run(None, feeds)
 
-        # outputs[0]: (1, seq_len, hidden_dim).  bge uses the [CLS] token as the
-        # sentence embedding, but mean-pooling over non-pad tokens is robust
-        # across export variants and matches the existing dense path; both are
-        # L2-normalized so cosine ordering is what matters.
-        token_embeddings = outputs[0][0]  # (seq_len, hidden_dim)
-        mask = np.array(attention_mask, dtype=np.float32)
+        # outputs[0] is last_hidden_state: (1, seq_len, hidden_dim).  bge-small-
+        # en-v1.5 is a CLS-pooling model (model card: "pooling: cls, normalize:
+        # true") -- the sentence embedding is token 0 (the [CLS] vector), NOT a
+        # mean over tokens.  Mean-pooling here is WRONG for bge and degrades
+        # retrieval; take the CLS row, then L2-normalize.
+        last_hidden_state = outputs[0]  # (1, seq_len, hidden_dim)
+        cls_vec = last_hidden_state[:, 0, :][0]  # token 0 -> (hidden_dim,)
 
-        masked = token_embeddings * mask[:, np.newaxis]
-        summed = masked.sum(axis=0)
-        count = mask.sum()
-        if count == 0:
-            return None
-        mean_vec = summed / count
-
-        norm = np.linalg.norm(mean_vec)
+        norm = np.linalg.norm(cls_vec)
         if norm > 0:
-            mean_vec = mean_vec / norm
+            cls_vec = cls_vec / norm
 
-        return mean_vec.astype(np.float32).tolist()
+        return cls_vec.astype(np.float32).tolist()
 
     def embed_query(self, text: str) -> list[float] | None:
         """Embed ``text`` as a SEARCH QUERY (bge instruction prefixed)."""

--- a/mnemosyne/embeddings/semantic_backend.py
+++ b/mnemosyne/embeddings/semantic_backend.py
@@ -1,0 +1,420 @@
+# Copyright 2026 Cast Rock Innovation L.L.C.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Semantic sentence-embedding backend (BGE-small-en-v1.5, quantized ONNX).
+
+This backend produces 384-dim semantic embeddings that discriminate meaning,
+not just surface tokens, so a query like "what animal do I like" can retrieve a
+stored "I like dogs" even with no lexical overlap.  It runs the quantized ONNX
+model 100% locally on CPU via onnxruntime; there is no network call at query
+time.  It is a strict superset of the lighter hashed and TF-IDF lanes and is
+opt-in (it needs the ``[dense]`` extra and a one-time model download).
+
+Why a separate module from ``dense_backend``:
+    ``dense_backend.DenseBackend`` is wired to a specific MiniLM artifact, its
+    own download layout, and float32 storage.  This backend targets a different
+    model with different sourcing (project-owned, pinned, SHA-verified),
+    query-vs-passage prompting, a shared cross-project cache, an offline
+    pre-place path, and int8 storage.  Keeping it separate avoids disturbing
+    the existing, proven doc path.
+
+Model artifact (sourcing contract)
+-----------------------------------
+The model is NOT bundled in this repository and is NOT downloaded from a
+personal account.  A maintainer converts + quantizes the official BAAI weights
+ONCE (see ``tools/convert_bge_small_onnx.py``), hosts the result at a
+PROJECT-OWNED location, and pins it here:
+
+    * MODEL_REPO / MODEL_BASE_URL -- where the artifact lives.  A placeholder
+      default ships; set the real value on publish (or override via config /
+      the ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env var / ``base_url`` argument).
+    * MODEL_REVISION -- pin to a SPECIFIC immutable commit hash on publish.
+    * MODEL_SHA256 / TOKENIZER_SHA256 -- the exact hashes the conversion tool
+      printed.  When set, downloads are verified and REJECTED + deleted on
+      mismatch.  When None, a LOUD warning is emitted (unpinned / unverified).
+    * MODEL_FILENAME / TOKENIZER_FILENAME -- the quantized onnx + tokenizer.
+
+Security model
+--------------
+- Local-only inference (CPUExecutionProvider, single-threaded, no telemetry).
+- One-time download over stdlib HTTPS (urllib) -- no huggingface_hub, no extra
+  runtime dependency.  Downloaded files are SHA-256 verified (when pinned) and
+  chmod 0600.  On a hash mismatch the partial file is removed and the load
+  fails closed.
+- Offline supported: point ``local_path`` at a directory holding pre-placed
+  ``model_quantized.onnx`` + ``tokenizer.json`` and the network is never
+  touched.  An already-cached file is likewise reused without a download.
+- Graceful degradation: if onnxruntime or numpy is missing, the model files
+  are unavailable, or the text is empty, every embed call returns ``None`` and
+  the caller simply skips this lane.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mnemosyne.embeddings.dense_backend import (
+    _WordPieceTokenizer,
+    _download_file,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mnemosyne.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model constants -- the maintainer sets these on artifact publish.
+# ---------------------------------------------------------------------------
+
+#: Project-owned artifact location.  This is a DOCUMENTED PLACEHOLDER -- the
+#: maintainer replaces it (or overrides it at runtime) with the real host they
+#: publish the converted artifact to.  It MUST NOT point at a personal account.
+#: Override precedence: ``base_url`` arg > config ``semantic_model_repo`` >
+#: ``MNEMOSYNE_SEMANTIC_MODEL_REPO`` env var > this default.
+MODEL_REPO: str = "https://models.example-project.invalid/bge-small-en-v1.5"
+
+#: Alias kept for callers/readers who think in "base URL" terms.
+MODEL_BASE_URL: str = MODEL_REPO
+
+#: Pin to a SPECIFIC immutable revision/commit when the artifact is published.
+#: A revision path segment is only appended when this is set.
+MODEL_REVISION: str | None = None  # set on artifact publish
+
+#: The quantized ONNX model + the HuggingFace tokenizer.json filenames.
+MODEL_FILENAME: str = "model_quantized.onnx"
+TOKENIZER_FILENAME: str = "tokenizer.json"
+
+#: Expected SHA-256 of each artifact.  SET THESE on publish to the values the
+#: conversion tool prints.  When None the download is UNVERIFIED -- a loud
+#: warning fires; do not ship a public release with these unset.
+MODEL_SHA256: str | None = None      # set on artifact publish
+TOKENIZER_SHA256: str | None = None  # set on artifact publish
+
+#: Output dimensionality and max sequence length for bge-small-en-v1.5.
+MODEL_DIM: int = 384
+MAX_SEQ_LEN: int = 512
+
+#: bge retrieval models expect this instruction prefixed to the QUERY ONLY.
+#: Stored passages are embedded with no prefix.  This is the official BAAI
+#: retrieval instruction for the v1.5 small/base/large English models.
+QUERY_INSTRUCTION: str = (
+    "Represent this sentence for searching relevant passages:"
+)
+
+#: Environment variable that overrides MODEL_REPO at runtime.
+ENV_MODEL_REPO: str = "MNEMOSYNE_SEMANTIC_MODEL_REPO"
+#: Environment variable that overrides the cache directory at runtime.
+ENV_CACHE_DIR: str = "MNEMOSYNE_MODEL_CACHE"
+
+
+# ---------------------------------------------------------------------------
+# Cache directory resolution (XDG-aware, shared across projects)
+# ---------------------------------------------------------------------------
+
+
+def default_cache_dir() -> str:
+    """Return the shared model cache dir, honoring XDG_CACHE_HOME.
+
+    Defaults to ``~/.cache/mnemosyne/models`` (or ``$XDG_CACHE_HOME/mnemosyne/
+    models``).  A single shared cache means the (~10 MB) artifact is downloaded
+    once per machine and reused by every project on it.
+    """
+    override = os.environ.get(ENV_CACHE_DIR)
+    if override:
+        return override
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return str(base / "mnemosyne" / "models")
+
+
+def _resolve_base_url(config: "Config | None", base_url: str | None) -> str:
+    """Resolve the artifact base URL by precedence (arg > config > env > default)."""
+    if base_url:
+        return base_url
+    if config is not None:
+        cfg_repo = getattr(
+            getattr(config, "embedding", None), "semantic_model_repo", None
+        )
+        if cfg_repo:
+            return cfg_repo
+    env_repo = os.environ.get(ENV_MODEL_REPO)
+    if env_repo:
+        return env_repo
+    return MODEL_REPO
+
+
+def _artifact_url(base_url: str, filename: str) -> str:
+    """Join base URL + optional pinned revision + filename into a download URL."""
+    parts = [base_url.rstrip("/")]
+    if MODEL_REVISION:
+        parts.append(MODEL_REVISION)
+    parts.append(filename)
+    return "/".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Semantic backend
+# ---------------------------------------------------------------------------
+
+
+class SemanticBackend:
+    """BGE-small-en-v1.5 semantic embedding backend (quantized ONNX, CPU-only).
+
+    Args:
+        config: Mnemosyne :class:`~mnemosyne.config.Config` instance (optional;
+            used only to read ``embedding.semantic_model_repo`` /
+            ``embedding.semantic_local_path`` overrides).
+        cache_dir: Directory to cache downloaded model files.  Defaults to the
+            shared XDG cache (:func:`default_cache_dir`).
+        local_path: Offline directory holding pre-placed ``model_quantized.onnx``
+            + ``tokenizer.json``.  When set (or readable from config), the
+            network is NEVER contacted.
+        base_url: Override the artifact base URL directly (highest precedence).
+    """
+
+    def __init__(
+        self,
+        config: "Config | None" = None,
+        *,
+        cache_dir: str | None = None,
+        local_path: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self._config = config
+        self._cache_dir = cache_dir or default_cache_dir()
+        # local_path precedence: explicit arg > config.embedding.semantic_local_path
+        cfg_local = None
+        if config is not None:
+            cfg_local = getattr(
+                getattr(config, "embedding", None), "semantic_local_path", None
+            )
+        self._local_path = local_path or cfg_local
+        self._base_url = _resolve_base_url(config, base_url)
+        self._session = None  # lazy onnxruntime.InferenceSession
+        self._tokenizer: _WordPieceTokenizer | None = None  # lazy
+
+    # ------------------------------------------------------------------
+    # Model lifecycle
+    # ------------------------------------------------------------------
+
+    def _resolve_paths(self) -> tuple[str, str]:
+        """Return (model_path, tokenizer_path) for the active source dir."""
+        source_dir = self._local_path or self._cache_dir
+        return (
+            os.path.join(source_dir, MODEL_FILENAME),
+            os.path.join(source_dir, TOKENIZER_FILENAME),
+        )
+
+    def _ensure_model(self) -> None:
+        """Load the ONNX session, downloading + verifying the artifact if needed.
+
+        Raises ``ImportError`` if onnxruntime is absent (caller treats as a
+        graceful skip).  Raises other exceptions on a hard failure (missing
+        offline files, SHA mismatch, corrupt model); :meth:`embed` catches them.
+        """
+        if self._session is not None:
+            return
+
+        import onnxruntime  # lazy import -- graceful if not installed
+
+        model_path, tokenizer_path = self._resolve_paths()
+
+        if self._local_path:
+            # Offline mode: files MUST already be present.  Never touch network.
+            if not os.path.isfile(model_path) or not os.path.isfile(
+                tokenizer_path
+            ):
+                raise FileNotFoundError(
+                    "semantic model local_path is set but "
+                    f"{MODEL_FILENAME} / {TOKENIZER_FILENAME} were not found "
+                    f"in {self._local_path!r}"
+                )
+        else:
+            self._maybe_warn_unverified()
+            if not os.path.isfile(model_path):
+                url = _artifact_url(self._base_url, MODEL_FILENAME)
+                logger.info("Downloading semantic model from %s", url)
+                _download_file(url, model_path, MODEL_SHA256)
+            if not os.path.isfile(tokenizer_path):
+                url = _artifact_url(self._base_url, TOKENIZER_FILENAME)
+                logger.info("Downloading tokenizer from %s", url)
+                _download_file(url, tokenizer_path, TOKENIZER_SHA256)
+
+        opts = onnxruntime.SessionOptions()
+        opts.log_severity_level = 3  # suppress warnings
+        opts.inter_op_num_threads = 1
+        opts.intra_op_num_threads = 1
+
+        self._session = onnxruntime.InferenceSession(
+            model_path,
+            sess_options=opts,
+            providers=["CPUExecutionProvider"],
+        )
+        self._tokenizer = _WordPieceTokenizer(tokenizer_path)
+
+    @staticmethod
+    def _maybe_warn_unverified() -> None:
+        """Emit a loud warning when SHA-256 pins are unset before a download."""
+        missing = []
+        if MODEL_SHA256 is None:
+            missing.append("MODEL_SHA256")
+        if TOKENIZER_SHA256 is None:
+            missing.append("TOKENIZER_SHA256")
+        if missing:
+            logger.warning(
+                "SECURITY: semantic model is UNPINNED/UNVERIFIED -- %s are not "
+                "set, so the downloaded artifact's integrity is NOT checked. "
+                "Set the SHA-256 pins (and a pinned MODEL_REVISION) before any "
+                "production use, or pre-place a trusted artifact via local_path.",
+                " and ".join(missing),
+            )
+
+    # ------------------------------------------------------------------
+    # Embedding
+    # ------------------------------------------------------------------
+
+    def embed(self, text: str, *, is_query: bool = False) -> list[float] | None:
+        """Embed ``text`` into a 384-dim L2-normalized vector, or ``None``.
+
+        Args:
+            text: The text to embed.
+            is_query: When True, the bge query instruction is prefixed (use this
+                for SEARCH queries).  Stored passages MUST use ``False`` so they
+                are not prefixed -- mixing the two degrades retrieval.
+
+        Returns ``None`` when onnxruntime/numpy is unavailable, the model cannot
+        be loaded, or ``text`` is empty -- the caller then skips this lane.
+        """
+        if not text or not text.strip():
+            return None
+
+        try:
+            self._ensure_model()
+        except ImportError:
+            return None
+        except Exception:
+            logger.warning("Failed to load semantic model", exc_info=True)
+            return None
+
+        try:
+            import numpy as np
+        except ImportError:
+            return None
+
+        assert self._tokenizer is not None
+        assert self._session is not None
+
+        prompt = (
+            f"{QUERY_INSTRUCTION} {text.strip()}" if is_query else text.strip()
+        )
+        input_ids, attention_mask = self._tokenizer.tokenize(
+            prompt, max_length=MAX_SEQ_LEN
+        )
+
+        ids_arr = np.array([input_ids], dtype=np.int64)
+        mask_arr = np.array([attention_mask], dtype=np.int64)
+        type_arr = np.zeros_like(ids_arr)
+
+        feeds = {
+            "input_ids": ids_arr,
+            "attention_mask": mask_arr,
+            "token_type_ids": type_arr,
+        }
+        input_names = {inp.name for inp in self._session.get_inputs()}
+        feeds = {k: v for k, v in feeds.items() if k in input_names}
+
+        outputs = self._session.run(None, feeds)
+
+        # outputs[0]: (1, seq_len, hidden_dim).  bge uses the [CLS] token as the
+        # sentence embedding, but mean-pooling over non-pad tokens is robust
+        # across export variants and matches the existing dense path; both are
+        # L2-normalized so cosine ordering is what matters.
+        token_embeddings = outputs[0][0]  # (seq_len, hidden_dim)
+        mask = np.array(attention_mask, dtype=np.float32)
+
+        masked = token_embeddings * mask[:, np.newaxis]
+        summed = masked.sum(axis=0)
+        count = mask.sum()
+        if count == 0:
+            return None
+        mean_vec = summed / count
+
+        norm = np.linalg.norm(mean_vec)
+        if norm > 0:
+            mean_vec = mean_vec / norm
+
+        return mean_vec.astype(np.float32).tolist()
+
+    def embed_query(self, text: str) -> list[float] | None:
+        """Embed ``text`` as a SEARCH QUERY (bge instruction prefixed)."""
+        return self.embed(text, is_query=True)
+
+    def embed_passage(self, text: str) -> list[float] | None:
+        """Embed ``text`` as a STORED PASSAGE (no prefix)."""
+        return self.embed(text, is_query=False)
+
+    # ------------------------------------------------------------------
+    # Storage helpers
+    # ------------------------------------------------------------------
+
+    def embed_to_int8_bytes(
+        self, text: str, *, is_query: bool = False
+    ) -> bytes | None:
+        """Embed and pack as ``MODEL_DIM`` int8 bytes for compact BLOB storage.
+
+        The float vector is L2-normalized, so scaling by 127 and clamping to
+        ``[-127, 127]`` keeps quantization error small.  Pairs with the
+        ``"int8"`` encoding of :func:`mnemosyne.embeddings.vector_search`.
+        """
+        vec = self.embed(text, is_query=is_query)
+        if vec is None:
+            return None
+        q = [max(-127, min(127, int(round(x * 127)))) for x in vec]
+        return struct.pack(f"{len(q)}b", *q)
+
+    def embed_to_float32_bytes(
+        self, text: str, *, is_query: bool = False
+    ) -> bytes | None:
+        """Embed and pack as float32 little-endian bytes (full precision)."""
+        vec = self.embed(text, is_query=is_query)
+        if vec is None:
+            return None
+        return struct.pack(f"<{len(vec)}f", *vec)
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_available() -> bool:
+        """Return True if onnxruntime (and numpy) can be imported."""
+        try:
+            import numpy  # noqa: F401
+            import onnxruntime  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+
+__all__ = [
+    "SemanticBackend",
+    "MODEL_REPO",
+    "MODEL_BASE_URL",
+    "MODEL_REVISION",
+    "MODEL_FILENAME",
+    "TOKENIZER_FILENAME",
+    "MODEL_SHA256",
+    "TOKENIZER_SHA256",
+    "MODEL_DIM",
+    "MAX_SEQ_LEN",
+    "QUERY_INSTRUCTION",
+    "default_cache_dir",
+]

--- a/mnemosyne/embeddings/vector_search.py
+++ b/mnemosyne/embeddings/vector_search.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Cast Rock Innovation L.L.C.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Generic brute-force cosine search over packed vector BLOBs.
+
+This module is storage-agnostic and partition-agnostic.  It scores a single
+query vector against a set of stored vectors -- each stored as a packed binary
+BLOB in some column of some table -- and returns the top-k by cosine
+similarity.  Callers parameterize the table, the id column, the vector column,
+and the on-disk encoding (int8 or float32), so the same routine serves any
+partition that keeps dense vectors as a SQLite BLOB.
+
+Design notes
+------------
+- Pure brute force + numpy.  No ANN index, no sqlite extension, no loadable
+  module.  At the scales this engine targets (tens of thousands of short
+  records) a linear scan in numpy is fast and has zero external moving parts.
+- Two layers are exposed:
+    * :func:`cosine_topk` -- the pure-compute core.  Takes a query vector and
+      an iterable of ``(id, vector_bytes)`` pairs.  No database knowledge, so
+      it is trivially unit-testable and reusable from any backing store.
+    * :func:`cosine_topk_over_table` -- a thin SQLite convenience wrapper that
+      SELECTs ``(id_column, vector_column)`` from ``table`` (optionally
+      restricted to a candidate id set) and feeds the rows to
+      :func:`cosine_topk`.
+- Vectors are assumed L2-normalized at store time (the int8 and float32
+  encoders in this package both normalize before packing).  The query is
+  re-normalized defensively here so a caller passing an un-normalized query
+  still gets correct cosine ordering.
+- Encoding contract:
+    * ``"int8"``   -> 1 byte per dim, signed, value/127.0 maps back to floats.
+    * ``"float32"`` -> 4 bytes per dim, little-endian IEEE-754.
+  A stored BLOB whose length does not match ``dim`` for the chosen encoding is
+  skipped (it belongs to a different model_version / dim).
+- numpy is imported lazily inside the functions, mirroring the rest of the
+  embeddings package, so importing this module never hard-requires numpy.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING, Iterable, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as _np
+
+
+# ---------------------------------------------------------------------------
+# Encoding contract
+# ---------------------------------------------------------------------------
+
+#: Bytes-per-dimension for each supported on-disk encoding.
+_BYTES_PER_DIM = {"int8": 1, "float32": 4}
+
+
+def _decode_blob(vec_bytes: bytes, dim: int, encoding: str, np):
+    """Decode a stored BLOB into a float32 numpy vector, or ``None``.
+
+    Returns ``None`` when the BLOB length does not match ``dim`` for the
+    encoding (a vector from a different model/dim -- skip it rather than crash).
+    """
+    bpd = _BYTES_PER_DIM.get(encoding)
+    if bpd is None:
+        raise ValueError(f"unsupported encoding: {encoding!r}")
+    if not vec_bytes or len(vec_bytes) != dim * bpd:
+        return None
+    if encoding == "int8":
+        arr = np.frombuffer(vec_bytes, dtype=np.int8).astype(np.float32)
+        arr = arr / 127.0
+    else:  # float32
+        # .copy() so the array owns writable memory (frombuffer is read-only).
+        arr = np.frombuffer(vec_bytes, dtype="<f4").astype(np.float32).copy()
+    return arr
+
+
+def cosine_topk(
+    query_vec: Sequence[float],
+    rows: Iterable[tuple[int, bytes]],
+    *,
+    dim: int,
+    encoding: str = "int8",
+    top_k: int = 20,
+) -> list[tuple[int, float]]:
+    """Score ``query_vec`` against stored vector BLOBs; return top-k.
+
+    Args:
+        query_vec: The query vector (length ``dim``).  Re-normalized here, so it
+            need not be pre-normalized.
+        rows: Iterable of ``(id, vector_bytes)`` pairs.  ``id`` is opaque to this
+            function (chunk id, turn id, row id -- caller's choice).
+        dim: Expected vector dimensionality.  BLOBs of any other length are
+            skipped.
+        encoding: ``"int8"`` (1 byte/dim) or ``"float32"`` (4 bytes/dim).
+        top_k: Maximum number of results to return.
+
+    Returns:
+        A list of ``(id, similarity)`` tuples sorted by similarity descending,
+        truncated to ``top_k``.  Empty when the query is empty/zero-norm, numpy
+        is unavailable, or no stored vector matches ``dim``.
+    """
+    if not query_vec:
+        return []
+    try:
+        import numpy as np
+    except ImportError:  # numpy is an optional, lazy dependency here
+        return []
+
+    q = np.asarray(query_vec, dtype=np.float32)
+    if q.shape[0] != dim:
+        return []
+    q_norm = float(np.linalg.norm(q))
+    if q_norm == 0.0:
+        return []
+    q = q / q_norm
+
+    results: list[tuple[int, float]] = []
+    for row_id, vec_bytes in rows:
+        v = _decode_blob(vec_bytes, dim, encoding, np)
+        if v is None:
+            continue
+        v_norm = float(np.linalg.norm(v))
+        if v_norm == 0.0:
+            continue
+        sim = float(np.dot(q, v) / v_norm)
+        results.append((int(row_id), sim))
+
+    results.sort(key=lambda x: x[1], reverse=True)
+    return results[:top_k]
+
+
+def cosine_topk_over_table(
+    conn: sqlite3.Connection,
+    query_vec: Sequence[float],
+    *,
+    table: str,
+    id_column: str,
+    vector_column: str,
+    dim: int,
+    encoding: str = "int8",
+    top_k: int = 20,
+    candidate_ids: Sequence[int] | None = None,
+) -> list[tuple[int, float]]:
+    """Brute-force cosine top-k over a SQLite table of vector BLOBs.
+
+    Generic over the table / id column / vector column so any partition that
+    stores dense vectors as a BLOB can call it without bespoke SQL.
+
+    Args:
+        conn: An open ``sqlite3.Connection``.
+        query_vec: The query vector (length ``dim``); re-normalized internally.
+        table: Table name holding the vectors.
+        id_column: Name of the integer id column to return.
+        vector_column: Name of the BLOB column holding packed vectors.
+        dim: Expected vector dimensionality.
+        encoding: ``"int8"`` or ``"float32"`` (see :func:`cosine_topk`).
+        top_k: Maximum results.
+        candidate_ids: If given, only these ids are scored (pre-filtered by a
+            lexical lane, say).  ``None`` scans the whole table.
+
+    Returns:
+        ``[(id, similarity), ...]`` descending by similarity, length <= top_k.
+
+    Security / robustness:
+        ``table``, ``id_column``, and ``vector_column`` are validated as plain
+        SQL identifiers (alphanumeric + underscore) before interpolation, since
+        SQLite cannot parameterize identifiers.  Anything else raises
+        ``ValueError`` -- callers pass their own schema names, never user input,
+        but this keeps the helper safe by construction.
+    """
+    for ident in (table, id_column, vector_column):
+        if not _is_safe_identifier(ident):
+            raise ValueError(f"unsafe SQL identifier: {ident!r}")
+    if encoding not in _BYTES_PER_DIM:
+        raise ValueError(f"unsupported encoding: {encoding!r}")
+
+    if candidate_ids is not None and len(candidate_ids) == 0:
+        return []
+
+    sql = f"SELECT {id_column}, {vector_column} FROM {table}"
+    params: tuple = ()
+    if candidate_ids is not None:
+        placeholders = ",".join("?" for _ in candidate_ids)
+        sql += f" WHERE {id_column} IN ({placeholders})"
+        params = tuple(int(cid) for cid in candidate_ids)
+
+    try:
+        cursor = conn.execute(sql, params)
+        rows = ((row[0], row[1]) for row in cursor.fetchall())
+    except sqlite3.Error:
+        return []
+
+    return cosine_topk(
+        query_vec, rows, dim=dim, encoding=encoding, top_k=top_k
+    )
+
+
+def _is_safe_identifier(name: str) -> bool:
+    """True if *name* is a bare SQL identifier (letters/digits/underscore)."""
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(ch.isalnum() or ch == "_" for ch in name)
+
+
+__all__ = [
+    "cosine_topk",
+    "cosine_topk_over_table",
+]

--- a/mnemosyne/tests/test_semantic_backend.py
+++ b/mnemosyne/tests/test_semantic_backend.py
@@ -1,0 +1,405 @@
+# Copyright 2026 Cast Rock Innovation L.L.C.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for the BGE-small semantic embedding backend.
+
+The ONNX-dependent tests (real 384-dim vectors, SHA-verified download against a
+fixture model, offline local_path load) are gated on onnxruntime + numpy being
+importable, since this engine ships them only as the optional ``[dense]`` extra.
+The fallback-to-None paths and the pure-logic tests run unconditionally.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from mnemosyne.embeddings import semantic_backend as sb
+
+# ---------------------------------------------------------------------------
+# Optional-dependency gating
+# ---------------------------------------------------------------------------
+
+try:  # numpy + onnxruntime are the [dense] extra; absent in the base test env.
+    import numpy as _np  # noqa: F401
+    import onnxruntime as _ort  # noqa: F401
+
+    _HAVE_ORT = True
+except ImportError:
+    _HAVE_ORT = False
+
+try:
+    import onnx as _onnx  # noqa: F401
+
+    _HAVE_ONNX = True
+except ImportError:
+    _HAVE_ONNX = False
+
+requires_ort = pytest.mark.skipif(
+    not _HAVE_ORT, reason="onnxruntime/numpy not installed ([dense] extra)"
+)
+requires_onnx = pytest.mark.skipif(
+    not _HAVE_ONNX, reason="onnx not installed (needed to build the fixture)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal config double (the backend only reads embedding.* overrides)
+# ---------------------------------------------------------------------------
+
+
+class _Embedding:
+    def __init__(self, **kw):
+        self.semantic_model = kw.get("semantic_model")
+        self.semantic_model_repo = kw.get("semantic_model_repo")
+        self.semantic_local_path = kw.get("semantic_local_path")
+
+
+class _Config:
+    def __init__(self, **kw):
+        self.embedding = _Embedding(**kw)
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic tests (no heavy deps) -- always run
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAndUrlResolution:
+    def test_default_cache_dir_uses_xdg(self, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/xdgcache")
+        monkeypatch.delenv(sb.ENV_CACHE_DIR, raising=False)
+        assert sb.default_cache_dir() == "/tmp/xdgcache/mnemosyne/models"
+
+    def test_default_cache_dir_falls_back_to_home(self, monkeypatch):
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv(sb.ENV_CACHE_DIR, raising=False)
+        got = sb.default_cache_dir()
+        assert got.endswith("/.cache/mnemosyne/models")
+
+    def test_cache_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv(sb.ENV_CACHE_DIR, "/srv/models")
+        assert sb.default_cache_dir() == "/srv/models"
+
+    def test_base_url_precedence_arg_over_config_over_env(self, monkeypatch):
+        monkeypatch.setenv(sb.ENV_MODEL_REPO, "https://env.invalid/m")
+        cfg = _Config(semantic_model_repo="https://config.invalid/m")
+        # arg beats everything
+        assert (
+            sb._resolve_base_url(cfg, "https://arg.invalid/m")
+            == "https://arg.invalid/m"
+        )
+        # config beats env
+        assert sb._resolve_base_url(cfg, None) == "https://config.invalid/m"
+        # env beats default
+        assert (
+            sb._resolve_base_url(_Config(), None) == "https://env.invalid/m"
+        )
+
+    def test_base_url_default_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv(sb.ENV_MODEL_REPO, raising=False)
+        assert sb._resolve_base_url(_Config(), None) == sb.MODEL_REPO
+
+    def test_artifact_url_without_revision(self, monkeypatch):
+        monkeypatch.setattr(sb, "MODEL_REVISION", None)
+        url = sb._artifact_url("https://host.invalid/dir/", "model_quantized.onnx")
+        assert url == "https://host.invalid/dir/model_quantized.onnx"
+
+    def test_artifact_url_with_pinned_revision(self, monkeypatch):
+        monkeypatch.setattr(sb, "MODEL_REVISION", "abc123")
+        url = sb._artifact_url("https://host.invalid/dir", "tokenizer.json")
+        assert url == "https://host.invalid/dir/abc123/tokenizer.json"
+
+    def test_query_instruction_is_official_bge_prefix(self):
+        assert sb.QUERY_INSTRUCTION == (
+            "Represent this sentence for searching relevant passages:"
+        )
+
+
+class TestUnverifiedWarning:
+    def test_warns_when_shas_unset(self, monkeypatch, caplog):
+        monkeypatch.setattr(sb, "MODEL_SHA256", None)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", None)
+        with caplog.at_level("WARNING"):
+            sb.SemanticBackend._maybe_warn_unverified()
+        assert any(
+            "UNPINNED/UNVERIFIED" in rec.message for rec in caplog.records
+        )
+
+    def test_silent_when_shas_set(self, monkeypatch, caplog):
+        monkeypatch.setattr(sb, "MODEL_SHA256", "a" * 64)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", "b" * 64)
+        with caplog.at_level("WARNING"):
+            sb.SemanticBackend._maybe_warn_unverified()
+        assert not any(
+            "UNPINNED/UNVERIFIED" in rec.message for rec in caplog.records
+        )
+
+
+class TestGracefulFallback:
+    def test_empty_text_returns_none(self):
+        backend = sb.SemanticBackend(_Config())
+        assert backend.embed("") is None
+        assert backend.embed("   ") is None
+        assert backend.embed_query("") is None
+        assert backend.embed_passage("\n\t") is None
+
+    def test_onnxruntime_absent_returns_none(self, monkeypatch):
+        """Simulate onnxruntime import failure -> embed returns None.
+
+        Runs in every environment: when onnxruntime is genuinely absent the
+        import already fails; when it is present this forces the ImportError
+        branch.  Either way embed must degrade to None on non-empty text.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "onnxruntime":
+                raise ImportError("simulated missing onnxruntime")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        backend = sb.SemanticBackend(_Config())
+        assert backend.embed("hello world", is_query=True) is None
+        assert backend.embed("a stored passage") is None
+
+    def test_local_path_missing_files_returns_none(self, tmp_path, monkeypatch):
+        """local_path set but files absent -> _ensure_model raises -> None.
+
+        Skipped without onnxruntime, since _ensure_model imports it before the
+        file check; the file-missing branch is only reachable once ORT loads.
+        """
+        if not _HAVE_ORT:
+            pytest.skip("onnxruntime not installed")
+        backend = sb.SemanticBackend(_Config(), local_path=str(tmp_path))
+        assert backend.embed("query", is_query=True) is None
+
+    def test_is_available_reflects_environment(self):
+        assert sb.SemanticBackend.is_available() == _HAVE_ORT
+
+
+class TestConfigWiring:
+    def test_get_semantic_backend_disabled_returns_none(self):
+        from mnemosyne.embeddings import get_semantic_backend
+
+        assert get_semantic_backend(_Config(semantic_model=None)) is None
+
+    def test_get_semantic_backend_enabled_returns_instance(self):
+        from mnemosyne.embeddings import get_semantic_backend
+
+        backend = get_semantic_backend(
+            _Config(semantic_model="bge-small-en-v1.5")
+        )
+        assert isinstance(backend, sb.SemanticBackend)
+
+    def test_local_path_read_from_config(self, tmp_path):
+        backend = sb.SemanticBackend(
+            _Config(semantic_local_path=str(tmp_path))
+        )
+        assert backend._local_path == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Fixture ONNX builder -- only when onnx is importable
+# ---------------------------------------------------------------------------
+
+
+def _build_fixture_model(path: str, dim: int = sb.MODEL_DIM) -> None:
+    """Write a trivial ONNX model that outputs a (1, seq, dim) tensor.
+
+    The model ignores token *values*: it casts input_ids to float and projects
+    via a fixed identity-ish matmul to ``dim`` channels, giving a deterministic
+    per-token embedding.  Enough to exercise the tokenize -> run -> mean-pool ->
+    normalize path and assert the output dim + unit norm.
+    """
+    import numpy as np
+    import onnx
+    from onnx import TensorProto, helper, numpy_helper
+
+    # input_ids: (batch, seq) int64 ; attention_mask: (batch, seq) int64
+    input_ids = helper.make_tensor_value_info(
+        "input_ids", TensorProto.INT64, ["b", "s"]
+    )
+    attention_mask = helper.make_tensor_value_info(
+        "attention_mask", TensorProto.INT64, ["b", "s"]
+    )
+    output = helper.make_tensor_value_info(
+        "last_hidden_state", TensorProto.FLOAT, ["b", "s", dim]
+    )
+
+    cast = helper.make_node("Cast", ["input_ids"], ["ids_f"], to=TensorProto.FLOAT)
+    # unsqueeze to (b, s, 1) then matmul by (1, dim) weight -> (b, s, dim)
+    axes = numpy_helper.from_array(np.array([2], dtype=np.int64), name="axes")
+    unsqueeze = helper.make_node("Unsqueeze", ["ids_f", "axes"], ["ids_u"])
+    w = np.linspace(0.01, 0.5, dim, dtype=np.float32).reshape(1, dim)
+    weight = numpy_helper.from_array(w, name="proj")
+    matmul = helper.make_node("MatMul", ["ids_u", "proj"], ["last_hidden_state"])
+
+    graph = helper.make_graph(
+        [cast, unsqueeze, matmul],
+        "fixture",
+        [input_ids, attention_mask],
+        [output],
+        initializer=[axes, weight],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 13)]
+    )
+    model.ir_version = 9
+    onnx.save(model, path)
+
+
+def _write_fixture_tokenizer(path: str) -> None:
+    """Write a minimal HuggingFace-style tokenizer.json the WordPiece reader can parse."""
+    import json
+
+    vocab = {"[PAD]": 0, "[UNK]": 1, "[CLS]": 2, "[SEP]": 3}
+    for i, tok in enumerate(
+        ["dog", "dogs", "animal", "like", "cat", "favorite", "i"], start=4
+    ):
+        vocab[tok] = i
+    data = {"model": {"vocab": vocab}}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+@requires_ort
+@requires_onnx
+class TestRealEmbeddingWithFixture:
+    @pytest.fixture
+    def model_dir(self, tmp_path):
+        d = tmp_path / "models"
+        d.mkdir()
+        _build_fixture_model(str(d / sb.MODEL_FILENAME))
+        _write_fixture_tokenizer(str(d / sb.TOKENIZER_FILENAME))
+        return str(d)
+
+    def test_passage_is_384_dim_and_normalized(self, model_dir):
+        import numpy as np
+
+        backend = sb.SemanticBackend(_Config(), local_path=model_dir)
+        vec = backend.embed_passage("i like dogs")
+        assert vec is not None
+        assert len(vec) == sb.MODEL_DIM
+        assert abs(float(np.linalg.norm(np.array(vec))) - 1.0) < 1e-4
+
+    def test_query_is_384_dim_and_normalized(self, model_dir):
+        import numpy as np
+
+        backend = sb.SemanticBackend(_Config(), local_path=model_dir)
+        vec = backend.embed_query("what animal do i like")
+        assert vec is not None
+        assert len(vec) == sb.MODEL_DIM
+        assert abs(float(np.linalg.norm(np.array(vec))) - 1.0) < 1e-4
+
+    def test_query_prefix_changes_the_embedding(self, model_dir, monkeypatch):
+        """The query path must prepend the instruction; passage must not.
+
+        We capture the tokenizer input to prove the prefix is applied on query
+        embeds only.
+        """
+        backend = sb.SemanticBackend(_Config(), local_path=model_dir)
+        backend._ensure_model()
+        seen: list[str] = []
+        real_tokenize = backend._tokenizer.tokenize
+
+        def spy(text, max_length=sb.MAX_SEQ_LEN):
+            seen.append(text)
+            return real_tokenize(text, max_length=max_length)
+
+        monkeypatch.setattr(backend._tokenizer, "tokenize", spy)
+        backend.embed_passage("i like dogs")
+        backend.embed_query("i like dogs")
+        assert seen[0] == "i like dogs"  # passage: no prefix
+        assert seen[1].startswith(sb.QUERY_INSTRUCTION)  # query: prefixed
+        assert seen[1].endswith("i like dogs")
+
+    def test_int8_byte_packing_roundtrips_dim(self, model_dir):
+        backend = sb.SemanticBackend(_Config(), local_path=model_dir)
+        blob = backend.embed_to_int8_bytes("i like dogs")
+        assert blob is not None
+        assert len(blob) == sb.MODEL_DIM  # 1 byte per dim
+        ints = struct.unpack(f"{sb.MODEL_DIM}b", blob)
+        assert all(-127 <= x <= 127 for x in ints)
+
+    def test_offline_local_path_makes_no_network_call(
+        self, model_dir, monkeypatch
+    ):
+        """With local_path set, urllib must never be invoked."""
+        import urllib.request
+
+        def boom(*a, **k):  # pragma: no cover - asserts it is NOT called
+            raise AssertionError("network call attempted in offline mode")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        backend = sb.SemanticBackend(_Config(), local_path=model_dir)
+        vec = backend.embed_passage("i like dogs")
+        assert vec is not None and len(vec) == sb.MODEL_DIM
+
+    def test_cached_files_skip_download(self, model_dir, monkeypatch):
+        """Files already in the cache dir -> no download attempted."""
+        import urllib.request
+
+        def boom(*a, **k):  # pragma: no cover
+            raise AssertionError("download attempted though cache is populated")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        # Use cache_dir (not local_path) but pre-populate it; download is skipped
+        # because os.path.isfile() is true for both files.
+        backend = sb.SemanticBackend(_Config(), cache_dir=model_dir)
+        assert backend.embed_passage("i like dogs") is not None
+
+
+@requires_ort
+@requires_onnx
+class TestShaVerifiedDownload:
+    """SHA-256 mismatch on a (mocked) download -> rejected + file removed."""
+
+    def test_sha_mismatch_rejects_and_removes_file(
+        self, tmp_path, monkeypatch
+    ):
+        import os
+        import urllib.request
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+
+        # Build a real fixture model + tokenizer to serve as the "download".
+        src = tmp_path / "src"
+        src.mkdir()
+        _build_fixture_model(str(src / sb.MODEL_FILENAME))
+        _write_fixture_tokenizer(str(src / sb.TOKENIZER_FILENAME))
+        model_bytes = (src / sb.MODEL_FILENAME).read_bytes()
+
+        class _FakeResp:
+            def __init__(self, payload):
+                self._payload = payload
+                self._read = False
+
+            def read(self, n=-1):
+                if self._read:
+                    return b""
+                self._read = True
+                return self._payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, *a, **k):
+            return _FakeResp(model_bytes)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        # Pin a WRONG sha so verification fails.
+        monkeypatch.setattr(sb, "MODEL_SHA256", "0" * 64)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", None)
+
+        backend = sb.SemanticBackend(_Config(), cache_dir=str(cache))
+        # embed swallows the ValueError and returns None; the file must be gone.
+        assert backend.embed_passage("i like dogs") is None
+        assert not os.path.isfile(str(cache / sb.MODEL_FILENAME))

--- a/mnemosyne/tests/test_semantic_backend.py
+++ b/mnemosyne/tests/test_semantic_backend.py
@@ -102,14 +102,34 @@ class TestCacheAndUrlResolution:
         assert sb._resolve_base_url(_Config(), None) == sb.MODEL_REPO
 
     def test_artifact_url_without_revision(self, monkeypatch):
+        # A flat custom mirror (no pinned revision): filename joins directly.
         monkeypatch.setattr(sb, "MODEL_REVISION", None)
-        url = sb._artifact_url("https://host.invalid/dir/", "model_quantized.onnx")
-        assert url == "https://host.invalid/dir/model_quantized.onnx"
+        url = sb._artifact_url("https://host.invalid/dir/", "onnx/model_int8.onnx")
+        assert url == "https://host.invalid/dir/onnx/model_int8.onnx"
 
-    def test_artifact_url_with_pinned_revision(self, monkeypatch):
+    def test_artifact_url_with_pinned_revision_uses_hf_resolve(self, monkeypatch):
+        # The default path: HuggingFace-style resolve/<rev>/<path>, prefix kept.
         monkeypatch.setattr(sb, "MODEL_REVISION", "abc123")
-        url = sb._artifact_url("https://host.invalid/dir", "tokenizer.json")
-        assert url == "https://host.invalid/dir/abc123/tokenizer.json"
+        url = sb._artifact_url(
+            "https://huggingface.co/Xenova/bge-small-en-v1.5",
+            "onnx/model_int8.onnx",
+        )
+        assert url == (
+            "https://huggingface.co/Xenova/bge-small-en-v1.5"
+            "/resolve/abc123/onnx/model_int8.onnx"
+        )
+
+    def test_artifact_url_builds_for_pinned_defaults(self):
+        # The real shipped constants must produce a well-formed resolve URL.
+        url = sb._artifact_url(sb.MODEL_REPO, sb.MODEL_FILENAME)
+        assert url == (
+            f"{sb.MODEL_REPO}/resolve/{sb.MODEL_REVISION}/{sb.MODEL_FILENAME}"
+        )
+        assert "/resolve/" in url and url.endswith("onnx/model_int8.onnx")
+
+    def test_local_filename_flattens_remote_prefix(self):
+        assert sb._local_filename("onnx/model_int8.onnx") == "model_int8.onnx"
+        assert sb._local_filename("tokenizer.json") == "tokenizer.json"
 
     def test_query_instruction_is_official_bge_prefix(self):
         assert sb.QUERY_INSTRUCTION == (
@@ -134,6 +154,42 @@ class TestUnverifiedWarning:
             sb.SemanticBackend._maybe_warn_unverified()
         assert not any(
             "UNPINNED/UNVERIFIED" in rec.message for rec in caplog.records
+        )
+
+    def test_shipped_defaults_pin_model_warn_only_tokenizer(self, caplog):
+        """As shipped: the model IS sha-pinned; only the tokenizer warns."""
+        # The big-risk file is verified, the immutable-commit tokenizer is not.
+        assert sb.MODEL_SHA256 is not None and len(sb.MODEL_SHA256) == 64
+        assert sb.TOKENIZER_SHA256 is None
+        with caplog.at_level("WARNING"):
+            sb.SemanticBackend._maybe_warn_unverified()
+        msgs = [rec.message for rec in caplog.records]
+        warned = [m for m in msgs if "UNPINNED/UNVERIFIED" in m]
+        assert warned, "tokenizer should warn while unpinned"
+        # The warning names the tokenizer, not the model.
+        assert all("TOKENIZER_SHA256" in m for m in warned)
+        assert all("MODEL_SHA256" not in m for m in warned)
+
+
+class TestShippedModelPins:
+    """Lock the vetted Xenova artifact pins so a silent repoint is caught."""
+
+    def test_model_repo_is_xenova_prebuilt(self):
+        assert sb.MODEL_REPO == "https://huggingface.co/Xenova/bge-small-en-v1.5"
+        assert sb.MODEL_BASE_URL == sb.MODEL_REPO
+
+    def test_model_revision_is_immutable_commit_pin(self):
+        assert (
+            sb.MODEL_REVISION == "ea104dacec62c0de699686887e3f920caeb4f3e3"
+        )
+
+    def test_model_filename_is_int8_under_onnx_prefix(self):
+        assert sb.MODEL_FILENAME == "onnx/model_int8.onnx"
+        assert sb.TOKENIZER_FILENAME == "tokenizer.json"
+
+    def test_model_sha256_is_the_verified_hash(self):
+        assert sb.MODEL_SHA256 == (
+            "bf64d05457cb391fa88d045faf5927a15ea36d96228ddf23ea970087afdc1197"
         )
 
 
@@ -212,8 +268,10 @@ def _build_fixture_model(path: str, dim: int = sb.MODEL_DIM) -> None:
 
     The model ignores token *values*: it casts input_ids to float and projects
     via a fixed identity-ish matmul to ``dim`` channels, giving a deterministic
-    per-token embedding.  Enough to exercise the tokenize -> run -> mean-pool ->
-    normalize path and assert the output dim + unit norm.
+    per-token embedding.  Enough to exercise the tokenize -> run -> CLS-pool ->
+    normalize path and assert the output dim + unit norm.  (Every row here is a
+    scalar multiple of one weight vector, so it cannot distinguish CLS from mean
+    pooling -- :func:`_build_pooling_fixture_model` is used for that.)
     """
     import numpy as np
     import onnx
@@ -266,15 +324,76 @@ def _write_fixture_tokenizer(path: str) -> None:
         json.dump(data, f)
 
 
+#: Per-id embedding table used by the pooling fixture.  Rows are deliberately
+#: NOT colinear so token 0 (CLS) points in a different direction than the mean
+#: of all tokens -- which is what lets the test tell CLS-pooling from mean.
+_POOL_VOCAB_SIZE = 16
+
+
+def _pooling_embedding_table(dim: int) -> "object":
+    """A (vocab, dim) table whose rows differ in DIRECTION, not just scale."""
+    import numpy as np
+
+    rng = np.random.default_rng(1234)
+    table = rng.standard_normal((_POOL_VOCAB_SIZE, dim)).astype(np.float32)
+    # Make the CLS row (id 2) point somewhere clearly distinct so CLS != mean.
+    table[2] = 0.0
+    table[2, 0] = 1.0  # CLS embedding = unit e0
+    return table
+
+
+def _build_pooling_fixture_model(path: str, dim: int = sb.MODEL_DIM) -> None:
+    """ONNX model that Gathers a distinct per-id row -> last_hidden_state.
+
+    Unlike :func:`_build_fixture_model` (colinear rows), each token id maps to
+    its OWN embedding row via Gather, so the CLS row and the token-mean point in
+    different directions.  This is what makes a CLS-vs-mean assertion meaningful.
+    """
+    import onnx
+    from onnx import TensorProto, helper, numpy_helper
+
+    input_ids = helper.make_tensor_value_info(
+        "input_ids", TensorProto.INT64, ["b", "s"]
+    )
+    attention_mask = helper.make_tensor_value_info(
+        "attention_mask", TensorProto.INT64, ["b", "s"]
+    )
+    output = helper.make_tensor_value_info(
+        "last_hidden_state", TensorProto.FLOAT, ["b", "s", dim]
+    )
+
+    table = _pooling_embedding_table(dim)
+    emb = numpy_helper.from_array(table, name="emb")
+    # Gather(emb, input_ids) -> (b, s, dim)
+    gather = helper.make_node("Gather", ["emb", "input_ids"], ["last_hidden_state"], axis=0)
+
+    graph = helper.make_graph(
+        [gather],
+        "pooling_fixture",
+        [input_ids, attention_mask],
+        [output],
+        initializer=[emb],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 13)]
+    )
+    model.ir_version = 9
+    onnx.save(model, path)
+
+
 @requires_ort
 @requires_onnx
 class TestRealEmbeddingWithFixture:
     @pytest.fixture
     def model_dir(self, tmp_path):
+        # Files are placed FLAT (basename), matching how the loader resolves an
+        # offline/cache dir -- the remote ``onnx/`` prefix is stripped locally.
         d = tmp_path / "models"
         d.mkdir()
-        _build_fixture_model(str(d / sb.MODEL_FILENAME))
-        _write_fixture_tokenizer(str(d / sb.TOKENIZER_FILENAME))
+        _build_fixture_model(str(d / sb._local_filename(sb.MODEL_FILENAME)))
+        _write_fixture_tokenizer(
+            str(d / sb._local_filename(sb.TOKENIZER_FILENAME))
+        )
         return str(d)
 
     def test_passage_is_384_dim_and_normalized(self, model_dir):
@@ -355,6 +474,141 @@ class TestRealEmbeddingWithFixture:
 
 @requires_ort
 @requires_onnx
+class TestClsPoolingNotMean:
+    """bge-small-en-v1.5 is CLS-pooled: the embedding is token 0, NOT the mean.
+
+    Uses the Gather fixture (distinct, non-colinear per-id rows) so CLS and mean
+    point in different directions; asserts the produced vector equals the
+    normalized CLS row and does NOT equal the normalized token-mean.
+    """
+
+    @pytest.fixture
+    def pooling_dir(self, tmp_path):
+        d = tmp_path / "models"
+        d.mkdir()
+        _build_pooling_fixture_model(
+            str(d / sb._local_filename(sb.MODEL_FILENAME))
+        )
+        _write_fixture_tokenizer(
+            str(d / sb._local_filename(sb.TOKENIZER_FILENAME))
+        )
+        return str(d)
+
+    def test_embedding_is_cls_token_not_mean(self, pooling_dir):
+        import numpy as np
+
+        text = "i like dogs"  # several distinct tokens -> CLS row != mean row
+        backend = sb.SemanticBackend(_Config(), local_path=pooling_dir)
+        backend._ensure_model()  # builds the same tokenizer the embed path uses
+
+        # Reproduce the exact token sequence the backend feeds the model.
+        input_ids, attention_mask = backend._tokenizer.tokenize(
+            text, max_length=sb.MAX_SEQ_LEN
+        )
+        table = _pooling_embedding_table(sb.MODEL_DIM)
+        rows = table[np.array(input_ids)]  # (seq, dim) -- model output rows
+
+        # Expected CLS pooling: token 0 (the [CLS] row), L2-normalized.
+        cls_row = rows[0]
+        expected_cls = cls_row / np.linalg.norm(cls_row)
+
+        # The WRONG (mean) result for the same input, masked + L2-normalized.
+        mask = np.array(attention_mask, dtype=np.float32)
+        mean_row = (rows * mask[:, None]).sum(axis=0) / mask.sum()
+        expected_mean = mean_row / np.linalg.norm(mean_row)
+
+        # Sanity: the two pooling strategies genuinely differ for this fixture,
+        # otherwise the test would pass vacuously.
+        assert not np.allclose(expected_cls, expected_mean, atol=1e-3)
+
+        got = backend.embed_passage(text)
+        assert got is not None
+        got = np.array(got, dtype=np.float32)
+
+        # The backend must match CLS pooling and NOT mean pooling.
+        assert np.allclose(got, expected_cls, atol=1e-5)
+        assert not np.allclose(got, expected_mean, atol=1e-3)
+
+    def test_cls_row_is_token_zero_exactly(self, pooling_dir):
+        """A single-token passage isolates token 0 -> output == normalized CLS."""
+        import numpy as np
+
+        backend = sb.SemanticBackend(_Config(), local_path=pooling_dir)
+        backend._ensure_model()
+        table = _pooling_embedding_table(sb.MODEL_DIM)
+        # The CLS row of this fixture is the unit vector e0.
+        cls_norm = table[2] / np.linalg.norm(table[2])
+
+        got = np.array(backend.embed_passage("dog"), dtype=np.float32)
+        # Token 0 is always [CLS] (id 2); CLS pooling returns its normalized row.
+        assert np.allclose(got, cls_norm, atol=1e-5)
+        assert abs(float(np.linalg.norm(got)) - 1.0) < 1e-5
+
+
+@requires_ort
+class TestClsPoolingNoOnnx:
+    """CLS-pooling assertion that needs only onnxruntime+numpy (no ``onnx``).
+
+    The ``onnx`` package is the optional fixture *builder*; it is absent in the
+    base ``[dense]`` env, so the fixture-backed pooling tests above skip there.
+    This test injects a fake session whose ``run`` returns a crafted
+    ``last_hidden_state`` with non-colinear rows, so it proves the embed path
+    takes token 0 (CLS), NOT the mean, wherever onnxruntime is importable.
+    """
+
+    def test_embed_uses_cls_token_zero_not_mean(self, monkeypatch):
+        import numpy as np
+
+        # A (1, seq, dim) last_hidden_state with rows pointing different ways.
+        seq, dim = 4, sb.MODEL_DIM
+        rows = np.zeros((seq, dim), dtype=np.float32)
+        rows[0, 0] = 1.0   # CLS row -> e0
+        rows[1, 1] = 2.0   # other tokens -> other axes (so mean != e0)
+        rows[2, 2] = 3.0
+        rows[3, 3] = 4.0
+        last_hidden_state = rows[np.newaxis, :, :]  # (1, seq, dim)
+
+        class _FakeInput:
+            def __init__(self, name):
+                self.name = name
+
+        class _FakeSession:
+            def get_inputs(self):
+                return [_FakeInput("input_ids"), _FakeInput("attention_mask")]
+
+            def run(self, _outs, _feeds):
+                return [last_hidden_state]
+
+        class _FakeTok:
+            def tokenize(self, text, max_length=sb.MAX_SEQ_LEN):
+                # CLS at index 0; full attention over all 4 positions.
+                return [2, 5, 6, 7], [1, 1, 1, 1]
+
+        backend = sb.SemanticBackend(_Config())
+
+        def fake_ensure():
+            backend._session = _FakeSession()
+            backend._tokenizer = _FakeTok()
+
+        monkeypatch.setattr(backend, "_ensure_model", fake_ensure)
+
+        got = np.array(backend.embed_passage("anything"), dtype=np.float32)
+
+        # CLS pooling: normalized token-0 row == e0.
+        expected_cls = np.zeros(dim, dtype=np.float32)
+        expected_cls[0] = 1.0
+        # Mean pooling (the WRONG result) would blend all four axes.
+        masked_mean = rows.mean(axis=0)
+        expected_mean = masked_mean / np.linalg.norm(masked_mean)
+
+        assert not np.allclose(expected_cls, expected_mean, atol=1e-3)
+        assert np.allclose(got, expected_cls, atol=1e-6)
+        assert not np.allclose(got, expected_mean, atol=1e-3)
+        assert abs(float(np.linalg.norm(got)) - 1.0) < 1e-6
+
+
+@requires_ort
+@requires_onnx
 class TestShaVerifiedDownload:
     """SHA-256 mismatch on a (mocked) download -> rejected + file removed."""
 
@@ -370,9 +624,12 @@ class TestShaVerifiedDownload:
         # Build a real fixture model + tokenizer to serve as the "download".
         src = tmp_path / "src"
         src.mkdir()
-        _build_fixture_model(str(src / sb.MODEL_FILENAME))
-        _write_fixture_tokenizer(str(src / sb.TOKENIZER_FILENAME))
-        model_bytes = (src / sb.MODEL_FILENAME).read_bytes()
+        model_name = sb._local_filename(sb.MODEL_FILENAME)
+        _build_fixture_model(str(src / model_name))
+        _write_fixture_tokenizer(
+            str(src / sb._local_filename(sb.TOKENIZER_FILENAME))
+        )
+        model_bytes = (src / model_name).read_bytes()
 
         class _FakeResp:
             def __init__(self, payload):
@@ -402,4 +659,4 @@ class TestShaVerifiedDownload:
         backend = sb.SemanticBackend(_Config(), cache_dir=str(cache))
         # embed swallows the ValueError and returns None; the file must be gone.
         assert backend.embed_passage("i like dogs") is None
-        assert not os.path.isfile(str(cache / sb.MODEL_FILENAME))
+        assert not os.path.isfile(str(cache / model_name))

--- a/mnemosyne/tests/test_vector_search.py
+++ b/mnemosyne/tests/test_vector_search.py
@@ -1,0 +1,223 @@
+# Copyright 2026 Cast Rock Innovation L.L.C.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for the generic cosine-over-BLOB vector search helper.
+
+The scoring assertions need numpy (an optional, lazily-imported dependency),
+so they are gated.  The pure-Python identifier guard and the empty/zero-norm
+short-circuit run unconditionally.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import struct
+
+import pytest
+
+from mnemosyne.embeddings import vector_search as vs
+
+try:
+    import numpy as _np  # noqa: F401
+
+    _HAVE_NUMPY = True
+except ImportError:
+    _HAVE_NUMPY = False
+
+requires_numpy = pytest.mark.skipif(
+    not _HAVE_NUMPY, reason="numpy not installed (optional dense dependency)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Encoding helpers for hand-built fixture vectors
+# ---------------------------------------------------------------------------
+
+
+def _int8_blob(floats: list[float]) -> bytes:
+    q = [max(-127, min(127, int(round(x * 127)))) for x in floats]
+    return struct.pack(f"{len(q)}b", *q)
+
+
+def _float32_blob(floats: list[float]) -> bytes:
+    return struct.pack(f"<{len(floats)}f", *floats)
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic tests -- always run
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifierGuard:
+    def test_accepts_plain_identifiers(self):
+        assert vs._is_safe_identifier("turn_embeddings")
+        assert vs._is_safe_identifier("_private")
+        assert vs._is_safe_identifier("col123")
+
+    def test_rejects_injection_attempts(self):
+        assert not vs._is_safe_identifier("")
+        assert not vs._is_safe_identifier("1col")
+        assert not vs._is_safe_identifier("a b")
+        assert not vs._is_safe_identifier("t;DROP TABLE x")
+        assert not vs._is_safe_identifier("col-name")
+        assert not vs._is_safe_identifier('col"name')
+
+    def test_over_table_rejects_bad_identifier(self):
+        conn = sqlite3.connect(":memory:")
+        with pytest.raises(ValueError):
+            vs.cosine_topk_over_table(
+                conn,
+                [0.1, 0.2],
+                table="t; DROP TABLE x",
+                id_column="id",
+                vector_column="vec",
+                dim=2,
+            )
+
+    def test_over_table_rejects_bad_encoding(self):
+        conn = sqlite3.connect(":memory:")
+        with pytest.raises(ValueError):
+            vs.cosine_topk_over_table(
+                conn,
+                [0.1, 0.2],
+                table="t",
+                id_column="id",
+                vector_column="vec",
+                dim=2,
+                encoding="float16",
+            )
+
+
+class TestEmptyShortCircuits:
+    def test_empty_query_returns_empty(self):
+        assert vs.cosine_topk([], [(1, b"\x01\x02")], dim=2) == []
+
+    def test_empty_candidate_set_returns_empty(self):
+        conn = sqlite3.connect(":memory:")
+        out = vs.cosine_topk_over_table(
+            conn,
+            [0.1, 0.2],
+            table="t",
+            id_column="id",
+            vector_column="vec",
+            dim=2,
+            candidate_ids=[],
+        )
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Scoring tests -- require numpy
+# ---------------------------------------------------------------------------
+
+
+@requires_numpy
+class TestCosineTopK:
+    def test_ranks_by_similarity_int8(self):
+        # 3-dim hand-built vectors; query points along axis 0.
+        query = [1.0, 0.0, 0.0]
+        rows = [
+            (10, _int8_blob([1.0, 0.0, 0.0])),   # identical   -> ~1.0
+            (20, _int8_blob([0.0, 1.0, 0.0])),   # orthogonal  -> ~0.0
+            (30, _int8_blob([0.7, 0.7, 0.0])),   # 45 degrees  -> ~0.7
+        ]
+        out = vs.cosine_topk(query, rows, dim=3, encoding="int8", top_k=3)
+        ids = [r[0] for r in out]
+        assert ids == [10, 30, 20]
+        assert out[0][1] > out[1][1] > out[2][1]
+        assert out[0][1] == pytest.approx(1.0, abs=0.02)
+
+    def test_topk_truncates(self):
+        query = [1.0, 0.0]
+        rows = [(i, _int8_blob([1.0, 0.0])) for i in range(5)]
+        out = vs.cosine_topk(query, rows, dim=2, encoding="int8", top_k=2)
+        assert len(out) == 2
+
+    def test_float32_encoding(self):
+        query = [1.0, 0.0, 0.0]
+        rows = [
+            (1, _float32_blob([1.0, 0.0, 0.0])),
+            (2, _float32_blob([-1.0, 0.0, 0.0])),  # opposite -> -1.0
+        ]
+        out = vs.cosine_topk(query, rows, dim=3, encoding="float32", top_k=2)
+        assert out[0][0] == 1
+        assert out[0][1] == pytest.approx(1.0, abs=1e-5)
+        assert out[1][1] == pytest.approx(-1.0, abs=1e-5)
+
+    def test_wrong_length_blob_is_skipped(self):
+        query = [1.0, 0.0, 0.0]
+        rows = [
+            (1, _int8_blob([1.0, 0.0, 0.0])),  # dim 3 -- kept
+            (2, _int8_blob([1.0, 0.0])),       # dim 2 -- skipped
+        ]
+        out = vs.cosine_topk(query, rows, dim=3, encoding="int8", top_k=5)
+        assert [r[0] for r in out] == [1]
+
+    def test_zero_norm_stored_vector_skipped(self):
+        query = [1.0, 0.0, 0.0]
+        rows = [
+            (1, _int8_blob([0.0, 0.0, 0.0])),  # zero vector -- skipped
+            (2, _int8_blob([1.0, 0.0, 0.0])),
+        ]
+        out = vs.cosine_topk(query, rows, dim=3, encoding="int8", top_k=5)
+        assert [r[0] for r in out] == [2]
+
+    def test_query_wrong_dim_returns_empty(self):
+        out = vs.cosine_topk(
+            [1.0, 0.0], [(1, _int8_blob([1.0, 0.0, 0.0]))], dim=3
+        )
+        assert out == []
+
+
+@requires_numpy
+class TestCosineTopKOverTable:
+    @pytest.fixture
+    def conn(self):
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE turn_vectors (turn_id INTEGER PRIMARY KEY, vec BLOB)")
+        rows = [
+            (101, _int8_blob([1.0, 0.0, 0.0])),
+            (102, _int8_blob([0.0, 1.0, 0.0])),
+            (103, _int8_blob([0.6, 0.8, 0.0])),
+        ]
+        c.executemany("INSERT INTO turn_vectors VALUES (?, ?)", rows)
+        c.commit()
+        return c
+
+    def test_full_scan_ranks_correctly(self, conn):
+        out = vs.cosine_topk_over_table(
+            conn,
+            [1.0, 0.0, 0.0],
+            table="turn_vectors",
+            id_column="turn_id",
+            vector_column="vec",
+            dim=3,
+            top_k=3,
+        )
+        assert [r[0] for r in out] == [101, 103, 102]
+
+    def test_candidate_filter_restricts_scan(self, conn):
+        out = vs.cosine_topk_over_table(
+            conn,
+            [1.0, 0.0, 0.0],
+            table="turn_vectors",
+            id_column="turn_id",
+            vector_column="vec",
+            dim=3,
+            candidate_ids=[102, 103],
+        )
+        ids = [r[0] for r in out]
+        assert 101 not in ids
+        assert set(ids) == {102, 103}
+        assert ids[0] == 103  # closer to the query than 102
+
+    def test_missing_table_returns_empty(self, conn):
+        out = vs.cosine_topk_over_table(
+            conn,
+            [1.0, 0.0, 0.0],
+            table="turn_vectors",  # valid name, but query nonexistent column
+            id_column="turn_id",
+            vector_column="does_not_exist",
+            dim=3,
+        )
+        assert out == []


### PR DESCRIPTION
## Summary
Optional, CPU-only semantic embedding backend for retrieval, plus a reusable
cosine-over-BLOB search helper. Additive and OFF until configured; onnxruntime is
the only runtime dep (optional [dense] extra).

- embeddings/semantic_backend.py: bge-small-en-v1.5 backend. Uses a PRE-BUILT,
  reputable int8 ONNX (Xenova/bge-small-en-v1.5, pinned to an immutable commit +
  SHA-256 verified on download) -- no local conversion toolchain. CLS pooling
  (token 0) + L2-normalize (bge's documented pooling), query-instruction prefix on
  queries, CPU-only, graceful None when onnxruntime/model absent. Shared model
  cache with an offline local_path.
- embeddings/vector_search.py: generic brute-force cosine top-k over a SQLite BLOB
  column, parameterized by table/column. Existing doc-path search unchanged.

## Test plan
- [x] pytest green (mock/fixture; CLS-not-mean asserted; no network/no real model)
- [ ] first use downloads the pinned artifact (SHA-verified); set TOKENIZER_SHA256
      after first download (optional hardening)