### PR TITLE
Pin tokenizer.json SHA-256 + make the unverified-artifact warning per-artifact

### DIFF
--- a/mnemosyne/embeddings/semantic_backend.py
+++ b/mnemosyne/embeddings/semantic_backend.py
@@ -33,10 +33,11 @@ pinned to an immutable commit and SHA-verified here:
       ``resolve/<rev>/<path>`` layout).
     * MODEL_REVISION -- the immutable commit pin.  The download URL is built as
       ``<repo>/resolve/<rev>/<path>``.
-    * MODEL_SHA256 -- the verified hash of the int8 model; the download is
-      REJECTED + deleted on mismatch.  TOKENIZER_SHA256 is None (the pinned
-      commit makes tokenizer.json immutable; set it on first download to enable
-      verification) so a LOUD warning fires for it until set.
+    * MODEL_SHA256 / TOKENIZER_SHA256 -- the verified hashes of the int8 model
+      and tokenizer.json; each download is REJECTED + deleted on mismatch.  Both
+      are pinned, so the download verifies the model AND the tokenizer.  If
+      either is ever left None, a LOUD per-artifact warning names exactly which
+      file is unverified until its hash is set.
     * MODEL_FILENAME / TOKENIZER_FILENAME -- the int8 onnx (under ``onnx/``) and
       the tokenizer; cached locally by basename.
 
@@ -90,8 +91,9 @@ MODEL_REPO: str = "https://huggingface.co/Xenova/bge-small-en-v1.5"
 MODEL_BASE_URL: str = MODEL_REPO
 
 #: Immutable commit pin on the artifact repo.  A revision is ALWAYS used to
-#: build the download URL when set; this makes ``tokenizer.json`` (which has no
-#: SHA pin below) content-addressable, and pins the model bytes we verify.
+#: build the download URL when set; this makes every artifact (model and
+#: ``tokenizer.json``) content-addressable, on top of the explicit SHA-256 pins
+#: below that we verify each downloaded file against.
 MODEL_REVISION: str | None = "ea104dacec62c0de699686887e3f920caeb4f3e3"
 
 #: Remote paths of the int8 ONNX model + the HuggingFace tokenizer.json,
@@ -101,15 +103,18 @@ MODEL_REVISION: str | None = "ea104dacec62c0de699686887e3f920caeb4f3e3"
 MODEL_FILENAME: str = "onnx/model_int8.onnx"
 TOKENIZER_FILENAME: str = "tokenizer.json"
 
-#: Expected SHA-256 of each artifact.  The model is SHA-pinned (verified ->
-#: download is REJECTED + deleted on mismatch).  The tokenizer is left None:
-#: the pinned commit makes tokenizer.json immutable; compute its SHA-256 on
-#: first download and set this to enable verification.  (The big-risk file --
-#: the model -- IS SHA-pinned, so the artifact's integrity is checked.)
+#: Expected SHA-256 of each artifact.  BOTH are SHA-pinned (verified ->
+#: each download is REJECTED + deleted on mismatch), so the int8 model AND the
+#: tokenizer.json are checked against a known-good hash.  These are the hashes
+#: of the files served by the pinned ``MODEL_REVISION`` commit; rotate them
+#: together if the revision is ever bumped.  Leaving either None disables
+#: verification for that file and fires a loud per-artifact warning.
 MODEL_SHA256: str | None = (
     "bf64d05457cb391fa88d045faf5927a15ea36d96228ddf23ea970087afdc1197"
 )
-TOKENIZER_SHA256: str | None = None
+TOKENIZER_SHA256: str | None = (
+    "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66"
+)
 
 #: Output dimensionality and max sequence length for bge-small-en-v1.5.
 MODEL_DIM: int = 384
@@ -302,19 +307,45 @@ class SemanticBackend:
 
     @staticmethod
     def _maybe_warn_unverified() -> None:
-        """Emit a loud warning when SHA-256 pins are unset before a download."""
-        missing = []
-        if MODEL_SHA256 is None:
-            missing.append("MODEL_SHA256")
-        if TOKENIZER_SHA256 is None:
-            missing.append("TOKENIZER_SHA256")
-        if missing:
+        """Warn -- per artifact -- when a SHA-256 pin is unset before a download.
+
+        The message names exactly which file(s) lack a hash so the warning is
+        accurate:
+
+        * If MODEL_SHA256 is unset, the MODEL itself is unverified -- the serious
+          case (arbitrary downloaded code/weights run locally).  The message
+          also notes if the tokenizer is unverified alongside it.
+        * If only TOKENIZER_SHA256 is unset, the model IS verified and only
+          ``tokenizer.json`` is unpinned -- a narrow gap; the message says so
+          explicitly so it does not imply the model is unverified.
+        * If both are pinned (the shipped default), nothing is emitted.
+        """
+        model_unpinned = MODEL_SHA256 is None
+        tokenizer_unpinned = TOKENIZER_SHA256 is None
+
+        if model_unpinned:
+            # The model is the high-risk artifact; lead with it.
+            also = (
+                " (tokenizer.json is also unpinned)"
+                if tokenizer_unpinned
+                else ""
+            )
             logger.warning(
-                "SECURITY: semantic model is UNPINNED/UNVERIFIED -- %s are not "
-                "set, so the downloaded artifact's integrity is NOT checked. "
-                "Set the SHA-256 pins (and a pinned MODEL_REVISION) before any "
-                "production use, or pre-place a trusted artifact via local_path.",
-                " and ".join(missing),
+                "SECURITY: the semantic MODEL is UNPINNED/UNVERIFIED -- "
+                "MODEL_SHA256 is not set, so the downloaded model artifact's "
+                "integrity is NOT checked.%s Set the SHA-256 pin (and a pinned "
+                "MODEL_REVISION) before any production use, or pre-place a "
+                "trusted artifact via local_path.",
+                also,
+            )
+        elif tokenizer_unpinned:
+            # Narrow gap: model verified, only the tokenizer lacks a hash.
+            logger.warning(
+                "SECURITY: tokenizer.json is not SHA-pinned -- "
+                "TOKENIZER_SHA256 is not set, so the downloaded tokenizer's "
+                "integrity is NOT checked. The semantic MODEL IS verified "
+                "against MODEL_SHA256; set TOKENIZER_SHA256 to close this gap, "
+                "or pre-place a trusted tokenizer via local_path."
             )
 
     # ------------------------------------------------------------------

--- a/mnemosyne/tests/test_semantic_backend.py
+++ b/mnemosyne/tests/test_semantic_backend.py
@@ -137,38 +137,84 @@ class TestCacheAndUrlResolution:
         )
 
 
+def _security_warnings(caplog) -> list[str]:
+    """Return the SECURITY warning messages captured (the unverified-pin warns)."""
+    return [
+        rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING" and "SECURITY:" in rec.message
+    ]
+
+
 class TestUnverifiedWarning:
-    def test_warns_when_shas_unset(self, monkeypatch, caplog):
-        monkeypatch.setattr(sb, "MODEL_SHA256", None)
-        monkeypatch.setattr(sb, "TOKENIZER_SHA256", None)
+    """The per-artifact warning must name exactly which file lacks a SHA pin.
+
+    These drive ``_maybe_warn_unverified`` directly with crafted pin values, so
+    they never touch the network and are independent of the shipped defaults.
+    """
+
+    def test_shipped_defaults_emit_no_warning(self, caplog):
+        """As shipped BOTH artifacts are SHA-pinned -> no unpinned warning."""
+        # Guards the actual module-level constants, not crafted values.
+        assert sb.MODEL_SHA256 is not None and len(sb.MODEL_SHA256) == 64
+        assert sb.TOKENIZER_SHA256 is not None and len(sb.TOKENIZER_SHA256) == 64
         with caplog.at_level("WARNING"):
             sb.SemanticBackend._maybe_warn_unverified()
-        assert any(
-            "UNPINNED/UNVERIFIED" in rec.message for rec in caplog.records
-        )
+        assert not _security_warnings(caplog)
 
-    def test_silent_when_shas_set(self, monkeypatch, caplog):
+    def test_silent_when_both_shas_set(self, monkeypatch, caplog):
         monkeypatch.setattr(sb, "MODEL_SHA256", "a" * 64)
         monkeypatch.setattr(sb, "TOKENIZER_SHA256", "b" * 64)
         with caplog.at_level("WARNING"):
             sb.SemanticBackend._maybe_warn_unverified()
-        assert not any(
-            "UNPINNED/UNVERIFIED" in rec.message for rec in caplog.records
-        )
+        assert not _security_warnings(caplog)
 
-    def test_shipped_defaults_pin_model_warn_only_tokenizer(self, caplog):
-        """As shipped: the model IS sha-pinned; only the tokenizer warns."""
-        # The big-risk file is verified, the immutable-commit tokenizer is not.
-        assert sb.MODEL_SHA256 is not None and len(sb.MODEL_SHA256) == 64
-        assert sb.TOKENIZER_SHA256 is None
+    def test_model_unpinned_warning_names_the_model(self, monkeypatch, caplog):
+        """If the MODEL hash is unset, the warning calls out the MODEL."""
+        monkeypatch.setattr(sb, "MODEL_SHA256", None)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", "b" * 64)
         with caplog.at_level("WARNING"):
             sb.SemanticBackend._maybe_warn_unverified()
-        msgs = [rec.message for rec in caplog.records]
-        warned = [m for m in msgs if "UNPINNED/UNVERIFIED" in m]
-        assert warned, "tokenizer should warn while unpinned"
-        # The warning names the tokenizer, not the model.
+        warned = _security_warnings(caplog)
+        assert warned, "an unpinned model must warn"
+        assert all("MODEL_SHA256" in m for m in warned)
+        assert all("MODEL is UNPINNED" in m for m in warned)
+        # The tokenizer is pinned here, so it must not be flagged as unpinned.
+        assert all("tokenizer.json is also unpinned" not in m for m in warned)
+
+    def test_both_unpinned_warning_names_model_and_tokenizer(
+        self, monkeypatch, caplog
+    ):
+        """Both hashes unset -> the (model-led) warning also flags the tokenizer."""
+        monkeypatch.setattr(sb, "MODEL_SHA256", None)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", None)
+        with caplog.at_level("WARNING"):
+            sb.SemanticBackend._maybe_warn_unverified()
+        warned = _security_warnings(caplog)
+        assert warned, "both unpinned must warn"
+        assert all("MODEL_SHA256" in m for m in warned)
+        assert any("tokenizer.json is also unpinned" in m for m in warned)
+
+    def test_tokenizer_only_unpinned_names_tokenizer_and_says_model_verified(
+        self, monkeypatch, caplog
+    ):
+        """Model pinned, tokenizer not -> name only the tokenizer; model verified.
+
+        This is the case the old wording got wrong: it must NOT imply the model
+        is unverified.
+        """
+        monkeypatch.setattr(sb, "MODEL_SHA256", "a" * 64)
+        monkeypatch.setattr(sb, "TOKENIZER_SHA256", None)
+        with caplog.at_level("WARNING"):
+            sb.SemanticBackend._maybe_warn_unverified()
+        warned = _security_warnings(caplog)
+        assert warned, "an unpinned tokenizer must warn"
+        # Names the tokenizer hash; does NOT claim the model is unpinned.
         assert all("TOKENIZER_SHA256" in m for m in warned)
-        assert all("MODEL_SHA256" not in m for m in warned)
+        assert all("tokenizer.json is not SHA-pinned" in m for m in warned)
+        assert all("MODEL is UNPINNED" not in m for m in warned)
+        # And it states the model IS verified.
+        assert all("MODEL IS verified" in m for m in warned)
 
 
 class TestShippedModelPins:
@@ -191,6 +237,16 @@ class TestShippedModelPins:
         assert sb.MODEL_SHA256 == (
             "bf64d05457cb391fa88d045faf5927a15ea36d96228ddf23ea970087afdc1197"
         )
+
+    def test_tokenizer_sha256_is_pinned(self):
+        """The tokenizer is now SHA-pinned too (both artifacts verified).
+
+        Asserted as a 64-char lowercase hex string rather than a literal so a
+        future pin rotation (alongside MODEL_REVISION) does not re-break this.
+        """
+        assert sb.TOKENIZER_SHA256 is not None
+        assert len(sb.TOKENIZER_SHA256) == 64
+        assert all(c in "0123456789abcdef" for c in sb.TOKENIZER_SHA256)
 
 
 class TestGracefulFallback:


### PR DESCRIPTION
## Summary
Follow-up hardening to the semantic embedder (#35).

- Set TOKENIZER_SHA256 to the verified hash of the pinned tokenizer.json so BOTH
  the model and tokenizer are integrity-checked on download (either mismatch ->
  rejected + deleted). The model was already SHA-pinned; the tokenizer was not.
- Rewrite the unverified-artifact warning to be per-artifact and accurate: it
  named "the model" as unverified even when MODEL_SHA256 was set. It now warns
  only about whichever artifact actually lacks a hash (model vs tokenizer), states
  the model is verified when it is, and is silent when both are pinned.

## Test plan
- [x] pytest green (5 network-free warning cases + the pinned-hash assertion)